### PR TITLE
feat: Add template reference method

### DIFF
--- a/sdk-node/src/Inferable.ts
+++ b/sdk-node/src/Inferable.ts
@@ -303,6 +303,19 @@ export class Inferable {
   }
 
   /**
+   * Creates a template reference. This can be used to trigger runs of a template that was previously registered via the UI.
+   * @param id The ID of the template to reference.
+   * @returns A referenced template instance.
+   */
+  public async templateReference(id: string) {
+    return {
+      id,
+      run: (input: TemplateRunInput) =>
+        this.run({ ...input, template: { id, input: input.input } }),
+    };
+  }
+
+  /**
    * Creates a run.
    * @param input The run definition.
    * @returns A run handle.


### PR DESCRIPTION
`client.templateReference` allows a reference to a template via the id. Useful when you need to reference a template that was created via the UI of some other means.