### PR TITLE
chore: Evaluate clusterId lazily

### DIFF
--- a/sdk-dotnet/src/API/Models.cs
+++ b/sdk-dotnet/src/API/Models.cs
@@ -19,10 +19,16 @@ namespace Inferable.API
 
   public struct CreateMachineInput
   {
-    [JsonPropertyName("service")]
-    public required string Service { get; set; }
-    [JsonPropertyName("functions")]
-    public required List<Function> Functions { get; set; }
+    [
+      JsonPropertyName("service"),
+      JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)
+    ]
+    public string Service { get; set; }
+    [
+      JsonPropertyName("functions"),
+      JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)
+    ]
+    public List<Function> Functions { get; set; }
   }
 
   public struct CreateMachineResult

--- a/sdk-dotnet/src/Service.cs
+++ b/sdk-dotnet/src/Service.cs
@@ -13,7 +13,7 @@ namespace Inferable
     static int DEFAULT_RETRY_AFTER_SECONDS = 10;
 
     private string _name;
-    private string? _clusterId;
+    private string _clusterId;
     private bool _polling = false;
 
     private int _retryAfter = DEFAULT_RETRY_AFTER_SECONDS;
@@ -23,10 +23,11 @@ namespace Inferable
 
     private List<IFunctionRegistration> _functions = new List<IFunctionRegistration>();
 
-    internal Service(string name, ApiClient client, ILogger? logger, List<IFunctionRegistration> functions)
+    internal Service(string name, string clusterId, ApiClient client, ILogger? logger, List<IFunctionRegistration> functions)
     {
       this._name = name;
       this._functions = functions;
+      this._clusterId = clusterId;
 
       this._client = client;
       this._logger = logger ?? NullLogger.Instance;
@@ -51,7 +52,7 @@ namespace Inferable
     async internal Task<string> Start()
     {
       this._logger.LogDebug("Starting service '{name}'", this._name);
-      this._clusterId = await RegisterMachine();
+      await RegisterMachine();
 
       // Purposely not awaiting
       _ = this.runLoop();
@@ -131,7 +132,7 @@ namespace Inferable
       _logger.LogDebug($"Polling service {this._name}");
     }
 
-    async private Task<string> RegisterMachine()
+    async private Task RegisterMachine()
     {
       this._logger.LogDebug("Registering machine");
       var functions = new List<Function>();
@@ -152,8 +153,6 @@ namespace Inferable
           Service = this._name,
           Functions = functions
           });
-
-      return registerResult.ClusterId;
     }
   }
 }

--- a/sdk-dotnet/tests/Inferable.Tests/InferableTest.cs
+++ b/sdk-dotnet/tests/Inferable.Tests/InferableTest.cs
@@ -35,7 +35,6 @@ namespace Inferable.Tests
       return new InferableClient(new InferableOptions {
           ApiSecret = System.Environment.GetEnvironmentVariable("INFERABLE_TEST_API_SECRET")!,
           BaseUrl = System.Environment.GetEnvironmentVariable("INFERABLE_TEST_API_ENDPOINT")!,
-          ClusterId = System.Environment.GetEnvironmentVariable("INFERABLE_TEST_CLUSTER_ID")!,
       }, logger);
     }
 

--- a/sdk-go/main_test.go
+++ b/sdk-go/main_test.go
@@ -149,12 +149,11 @@ func TestInferableFunctions(t *testing.T) {
 
 // This should match the example in the readme
 func TestInferableE2E(t *testing.T) {
-	machineSecret, _, clusterID, apiEndpoint := util.GetTestVars()
+	machineSecret, _, _, apiEndpoint := util.GetTestVars()
 
 	client, err := New(InferableOptions{
 		APIEndpoint: apiEndpoint,
 		APISecret:   machineSecret,
-		ClusterID:   clusterID,
 	})
 
 	if err != nil {

--- a/sdk-go/service.go
+++ b/sdk-go/service.go
@@ -32,7 +32,7 @@ type service struct {
 	Name       string
 	Functions  map[string]Function
 	inferable  *Inferable
-	clusterId  string
+	ClusterID  string
 	ctx        context.Context
 	cancel     context.CancelFunc
 	retryAfter int
@@ -144,87 +144,9 @@ func (s *service) RegisterFunc(fn Function) (*FunctionReference, error) {
 	return &FunctionReference{Service: s.Name, Function: fn.Name}, nil
 }
 
-func (s *service) registerMachine() error {
-	// Check if there are any registered functions
-	if len(s.Functions) == 0 {
-		return fmt.Errorf("cannot register service '%s': no functions registered", s.Name)
-	}
-
-	// Prepare the payload for registration
-	payload := struct {
-		Service   string `json:"service"`
-		Functions []struct {
-			Name        string `json:"name"`
-			Description string `json:"description,omitempty"`
-			Schema      string `json:"schema,omitempty"`
-		} `json:"functions,omitempty"`
-	}{
-		Service: s.Name,
-	}
-
-	// Add registered functions to the payload
-	for _, fn := range s.Functions {
-		schemaJSON, err := json.Marshal(fn.schema)
-		if err != nil {
-			return fmt.Errorf("failed to marshal schema for function '%s': %v", fn.Name, err)
-		}
-
-		payload.Functions = append(payload.Functions, struct {
-			Name        string `json:"name"`
-			Description string `json:"description,omitempty"`
-			Schema      string `json:"schema,omitempty"`
-		}{
-			Name:        fn.Name,
-			Description: fn.Description,
-			Schema:      string(schemaJSON),
-		})
-	}
-
-	// Marshal the payload to JSON
-	jsonPayload, err := json.Marshal(payload)
-	if err != nil {
-		return fmt.Errorf("failed to marshal payload: %v", err)
-	}
-
-	// Prepare headers
-	headers := map[string]string{
-		"Authorization":          "Bearer " + s.inferable.apiSecret,
-		"X-Machine-ID":           s.inferable.machineID,
-		"X-Machine-SDK-Version":  Version,
-		"X-Machine-SDK-Language": "go",
-	}
-
-	// Call the registerMachine endpoint
-	options := client.FetchDataOptions{
-		Path:    "/machines",
-		Method:  "POST",
-		Headers: headers,
-		Body:    string(jsonPayload),
-	}
-
-	responseData, _, err, _ := s.inferable.fetchData(options)
-	if err != nil {
-		return fmt.Errorf("failed to register machine: %v", err)
-	}
-
-	// Parse the response
-	var response struct {
-		ClusterId string `json:"clusterId"`
-	}
-
-	err = json.Unmarshal(responseData, &response)
-	if err != nil {
-		return fmt.Errorf("failed to parse registration response: %v", err)
-	}
-
-	s.clusterId = response.ClusterId
-
-	return nil
-}
-
 // Start initializes the service, registers the machine, and starts polling for messages
 func (s *service) Start() error {
-	err := s.registerMachine()
+	_, err := s.inferable.registerMachine(s)
 	if err != nil {
 		return fmt.Errorf("failed to register machine: %v", err)
 	}
@@ -278,7 +200,7 @@ func (s *service) poll() error {
 	}
 
 	options := client.FetchDataOptions{
-		Path:    fmt.Sprintf("/clusters/%s/calls?acknowledge=true&service=%s&status=pending&limit=10", s.clusterId, s.Name),
+		Path:    fmt.Sprintf("/clusters/%s/calls?acknowledge=true&service=%s&status=pending&limit=10", s.ClusterID, s.Name),
 		Method:  "GET",
 		Headers: headers,
 	}
@@ -286,7 +208,7 @@ func (s *service) poll() error {
 	result, respHeaders, err, status := s.inferable.fetchData(options)
 
 	if status == 410 {
-		s.registerMachine()
+		s.inferable.registerMachine(s)
 	}
 
 	if err != nil {
@@ -395,7 +317,7 @@ func (s *service) persistJobResult(jobID string, result callResult) error {
 	}
 
 	options := client.FetchDataOptions{
-		Path:    fmt.Sprintf("/clusters/%s/calls/%s/result", s.clusterId, jobID),
+		Path:    fmt.Sprintf("/clusters/%s/calls/%s/result", s.ClusterID, jobID),
 		Method:  "POST",
 		Headers: headers,
 		Body:    string(payloadJSON),

--- a/sdk-go/service.go
+++ b/sdk-go/service.go
@@ -198,10 +198,10 @@ func (s *service) poll() error {
 		"X-Machine-SDK-Language": "go",
 	}
 
-  clusterId, err := s.inferable.GetClusterId()
-  if err != nil {
-    return fmt.Errorf("failed to get cluster id: %v", err)
-  }
+	clusterId, err := s.inferable.GetClusterId()
+	if err != nil {
+		return fmt.Errorf("failed to get cluster id: %v", err)
+	}
 
 	options := client.FetchDataOptions{
 		Path:    fmt.Sprintf("/clusters/%s/calls?acknowledge=true&service=%s&status=pending&limit=10", clusterId, s.Name),
@@ -320,10 +320,10 @@ func (s *service) persistJobResult(jobID string, result callResult) error {
 		"X-Machine-SDK-Language": "go",
 	}
 
-  clusterId, err := s.inferable.GetClusterId()
-  if err != nil {
-    return fmt.Errorf("failed to get cluster id: %v", err)
-  }
+	clusterId, err := s.inferable.GetClusterId()
+	if err != nil {
+		return fmt.Errorf("failed to get cluster id: %v", err)
+	}
 
 	options := client.FetchDataOptions{
 		Path:    fmt.Sprintf("/clusters/%s/calls/%s/result", clusterId, jobID),

--- a/sdk-go/service.go
+++ b/sdk-go/service.go
@@ -32,7 +32,6 @@ type service struct {
 	Name       string
 	Functions  map[string]Function
 	inferable  *Inferable
-	ClusterID  string
 	ctx        context.Context
 	cancel     context.CancelFunc
 	retryAfter int
@@ -199,8 +198,13 @@ func (s *service) poll() error {
 		"X-Machine-SDK-Language": "go",
 	}
 
+  clusterId, err := s.inferable.GetClusterId()
+  if err != nil {
+    return fmt.Errorf("failed to get cluster id: %v", err)
+  }
+
 	options := client.FetchDataOptions{
-		Path:    fmt.Sprintf("/clusters/%s/calls?acknowledge=true&service=%s&status=pending&limit=10", s.ClusterID, s.Name),
+		Path:    fmt.Sprintf("/clusters/%s/calls?acknowledge=true&service=%s&status=pending&limit=10", clusterId, s.Name),
 		Method:  "GET",
 		Headers: headers,
 	}
@@ -316,8 +320,13 @@ func (s *service) persistJobResult(jobID string, result callResult) error {
 		"X-Machine-SDK-Language": "go",
 	}
 
+  clusterId, err := s.inferable.GetClusterId()
+  if err != nil {
+    return fmt.Errorf("failed to get cluster id: %v", err)
+  }
+
 	options := client.FetchDataOptions{
-		Path:    fmt.Sprintf("/clusters/%s/calls/%s/result", s.ClusterID, jobID),
+		Path:    fmt.Sprintf("/clusters/%s/calls/%s/result", clusterId, jobID),
 		Method:  "POST",
 		Headers: headers,
 		Body:    string(payloadJSON),

--- a/sdk-node/src/contract.ts
+++ b/sdk-node/src/contract.ts
@@ -131,7 +131,7 @@ export const definition = {
       ...machineHeaders,
     }),
     body: z.object({
-      service: z.string(),
+      service: z.string().optional(),
       functions: z
         .array(
           z.object({
@@ -564,7 +564,6 @@ export const definition = {
           status: z
             .enum(["pending", "running", "paused", "done", "failed"])
             .nullable(),
-          parentWorkflowId: z.string().nullable(),
           test: z.boolean(),
           promptTemplateId: z.string().nullable(),
           promptTemplateVersion: z.number().nullable(),

--- a/sdk-node/src/tests/utils.ts
+++ b/sdk-node/src/tests/utils.ts
@@ -30,5 +30,4 @@ export const inferableInstance = () =>
   new Inferable({
     apiSecret: TEST_API_SECRET,
     endpoint: TEST_ENDPOINT,
-    clusterId: TEST_CLUSTER_ID,
   });


### PR DESCRIPTION
Retrieve clusterId from API rather than requiring it to be specified during client initialisation.

Relies on https://github.com/inferablehq/platform/pull/750