### PR TITLE
chore(sdk-node): Evaluate clusterId lazily

### DIFF
--- a/sdk-node/src/Inferable.test.ts
+++ b/sdk-node/src/Inferable.test.ts
@@ -240,6 +240,7 @@ describe("Functions", () => {
 
 // This should match the example in the readme
 describe("Inferable SDK End to End Test", () => {
+  jest.retryTimes(3);
   it("should trigger a run, call a function, and call a status change function", async () => {
     const client = inferableInstance();
 

--- a/sdk-node/src/contract.ts
+++ b/sdk-node/src/contract.ts
@@ -131,7 +131,7 @@ export const definition = {
       ...machineHeaders,
     }),
     body: z.object({
-      service: z.string(),
+      service: z.string().optional(),
       functions: z
         .array(
           z.object({
@@ -564,7 +564,6 @@ export const definition = {
           status: z
             .enum(["pending", "running", "paused", "done", "failed"])
             .nullable(),
-          parentWorkflowId: z.string().nullable(),
           test: z.boolean(),
           promptTemplateId: z.string().nullable(),
           promptTemplateVersion: z.number().nullable(),

--- a/sdk-node/src/tests/utils.ts
+++ b/sdk-node/src/tests/utils.ts
@@ -30,5 +30,4 @@ export const inferableInstance = () =>
   new Inferable({
     apiSecret: TEST_API_SECRET,
     endpoint: TEST_ENDPOINT,
-    clusterId: TEST_CLUSTER_ID,
   });


### PR DESCRIPTION
Retrieve clusterId from API rather than requiring it to be specified during client initialisation.

Relies on https://github.com/inferablehq/platform/pull/750