### PR TITLE
chore(sdk-dotnet): Evaluate clusterId lazily

### DIFF
--- a/sdk-dotnet/src/API/Models.cs
+++ b/sdk-dotnet/src/API/Models.cs
@@ -19,10 +19,16 @@ namespace Inferable.API
 
   public struct CreateMachineInput
   {
-    [JsonPropertyName("service")]
-    public required string Service { get; set; }
-    [JsonPropertyName("functions")]
-    public required List<Function> Functions { get; set; }
+    [
+      JsonPropertyName("service"),
+      JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)
+    ]
+    public string Service { get; set; }
+    [
+      JsonPropertyName("functions"),
+      JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)
+    ]
+    public List<Function> Functions { get; set; }
   }
 
   public struct CreateMachineResult

--- a/sdk-dotnet/src/Service.cs
+++ b/sdk-dotnet/src/Service.cs
@@ -13,7 +13,7 @@ namespace Inferable
     static int DEFAULT_RETRY_AFTER_SECONDS = 10;
 
     private string _name;
-    private string? _clusterId;
+    private string _clusterId;
     private bool _polling = false;
 
     private int _retryAfter = DEFAULT_RETRY_AFTER_SECONDS;
@@ -23,10 +23,11 @@ namespace Inferable
 
     private List<IFunctionRegistration> _functions = new List<IFunctionRegistration>();
 
-    internal Service(string name, ApiClient client, ILogger? logger, List<IFunctionRegistration> functions)
+    internal Service(string name, string clusterId, ApiClient client, ILogger? logger, List<IFunctionRegistration> functions)
     {
       this._name = name;
       this._functions = functions;
+      this._clusterId = clusterId;
 
       this._client = client;
       this._logger = logger ?? NullLogger.Instance;
@@ -51,7 +52,7 @@ namespace Inferable
     async internal Task<string> Start()
     {
       this._logger.LogDebug("Starting service '{name}'", this._name);
-      this._clusterId = await RegisterMachine();
+      await RegisterMachine();
 
       // Purposely not awaiting
       _ = this.runLoop();
@@ -131,7 +132,7 @@ namespace Inferable
       _logger.LogDebug($"Polling service {this._name}");
     }
 
-    async private Task<string> RegisterMachine()
+    async private Task RegisterMachine()
     {
       this._logger.LogDebug("Registering machine");
       var functions = new List<Function>();
@@ -152,8 +153,6 @@ namespace Inferable
           Service = this._name,
           Functions = functions
           });
-
-      return registerResult.ClusterId;
     }
   }
 }

--- a/sdk-dotnet/tests/Inferable.Tests/InferableTest.cs
+++ b/sdk-dotnet/tests/Inferable.Tests/InferableTest.cs
@@ -35,7 +35,6 @@ namespace Inferable.Tests
       return new InferableClient(new InferableOptions {
           ApiSecret = System.Environment.GetEnvironmentVariable("INFERABLE_TEST_API_SECRET")!,
           BaseUrl = System.Environment.GetEnvironmentVariable("INFERABLE_TEST_API_ENDPOINT")!,
-          ClusterId = System.Environment.GetEnvironmentVariable("INFERABLE_TEST_CLUSTER_ID")!,
       }, logger);
     }
 


### PR DESCRIPTION
Retrieve clusterId from API rather than requiring it to be specified during client initialisation.

Relies on https://github.com/inferablehq/platform/pull/750