### PR TITLE
fix: Correct Go toolchain version syntax

### DIFF
--- a/sdk-go/go.mod
+++ b/sdk-go/go.mod
@@ -1,6 +1,6 @@
 module github.com/inferablehq/inferable/sdk-go
 
-go 1.22
+go 1.22.9
 
 require (
 	github.com/invopop/jsonschema v0.12.0


### PR DESCRIPTION
This change updates the Go toolchain version in the sdk-go/go.mod file to adhere to the 1.N.P syntax required by Go 1.21 and later.