### PR TITLE
chore: Move changelog generation to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -551,3 +551,32 @@ jobs:
         ROLLBAR_ACCESS_TOKEN: ${{ secrets.CLOUD_ROLLBAR_ACCESS_TOKEN }}
         ROLLBAR_USERNAME: ${{ github.actor }}
         DEPLOY_ID: ${{ steps.rollbar_pre_deploy.outputs.deploy_id }}
+
+
+  generate_changelog:
+    needs: [check_changes, publish-cli, publish-node, publish-react, publish-dotnet, publish-go]
+    runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/main' }}
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Generate a changelog
+        uses: orhun/git-cliff-action@v3
+        with:
+          config: cliff.toml
+          args: --verbose
+        env:
+          OUTPUT: CHANGELOG.md
+          GITHUB_REPO: ${{ github.repository }}
+      - name: Commit changelog
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: 'CHANGELOG.md'
+          message: '[skip ci] chore: Update changelog'
+          default_author: github_actions
+          push: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,42 +44,6 @@ jobs:
             bootstrap:
               - 'bootstrap*/**'
 
-  generate_changelog:
-    needs: [check_changes, publish-cli, publish-node, publish-react, publish-dotnet, publish-go, create-archives]
-    runs-on: ubuntu-latest
-    if: |
-      always() && (
-        needs.check_changes.outputs.sdk_node == 'true' ||
-        needs.check_changes.outputs.sdk_react == 'true' ||
-        needs.check_changes.outputs.sdk_dotnet == 'true' ||
-        needs.check_changes.outputs.sdk_go == 'true' ||
-        needs.check_changes.outputs.cli == 'true' ||
-        needs.check_changes.outputs.bootstrap == 'true'
-      )
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Generate a changelog
-        uses: orhun/git-cliff-action@v3
-        with:
-          config: cliff.toml
-          args: --verbose
-        env:
-          OUTPUT: CHANGELOG.md
-          GITHUB_REPO: ${{ github.repository }}
-      - name: Commit changelog
-        uses: EndBug/add-and-commit@v9
-        with:
-          add: 'CHANGELOG.md'
-          message: '[skip ci] chore: Update changelog'
-          default_author: github_actions
-          push: true
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
   publish-cli:
     needs: check_changes
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Added `generate_changelog` job to `build.yml` workflow.
- Removed `generate_changelog` job from `publish.yml` workflow.
- Updated job dependencies and conditions for changelog generation.
- Utilized `orhun/git-cliff-action` for changelog creation.
- Committed changelog with `[skip ci] chore: Update changelog` message.