### PR TITLE
chore: Cleanup runConfigId / input merging

### DIFF
--- a/control-plane/src/modules/contract.ts
+++ b/control-plane/src/modules/contract.ts
@@ -524,17 +524,29 @@ export const definition = {
         .describe(
           "When provided, the run will be marked as as a test / evaluation",
         ),
+      configId: z
+        .string()
+        .optional()
+        .describe("The run configuration ID to use"),
+      input: z
+        .object({})
+        .passthrough()
+        .describe(
+          "Structured input arguments to merge with the initial prompt. The schema must match the run configuration input schema if defined",
+        )
+        .optional(),
       config: z
         .object({
-          id: z.string().describe("The run configuration ID"),
+          id: z.string().describe("DEPRECATED"),
           input: z
             .object({})
             .passthrough()
             .describe(
-              "The run configuration input arguments, the schema must match the run configuration input schema",
+              "DEPRECATED",
             )
             .optional(),
         })
+        .describe("DEPRECATED")
         .optional(),
       context: anyObject
         .optional()

--- a/control-plane/src/modules/prompt-templates.test.ts
+++ b/control-plane/src/modules/prompt-templates.test.ts
@@ -196,34 +196,5 @@ describe("prompt-templates", () => {
         },
       });
     });
-
-    it("should merge initialPrompt with run input", () => {
-      const options = {
-        input: {
-          name: "World",
-        },
-      };
-
-      const runConfig = {
-        id: "test-id",
-        name: "test-template",
-        initialPrompt: "Hello: ",
-        inputSchema: {
-          type: "object",
-          required: ["name"],
-          properties: {
-            name: { type: "string" },
-            extra: { type: "string" },
-          },
-        },
-        versions: [],
-      } as any;
-
-      const result = mergeRunConfigOptions(options, runConfig);
-
-      expect(result.error).toBeNull();
-      expect(result.options?.initialPrompt).toContain("Hello");
-      expect(result.options?.initialPrompt).toContain("World");
-    });
   });
 });

--- a/control-plane/src/modules/prompt-templates.ts
+++ b/control-plane/src/modules/prompt-templates.ts
@@ -442,10 +442,6 @@ export const mergeRunConfigOptions = (
     }
   }
 
-  if (options.input) {
-    mergedOptions.initialPrompt = `${mergedOptions.initialPrompt}\n\n<DATA>\n${JSON.stringify(options.input, null, 2)}\n</DATA>`;
-  }
-
   mergedOptions.messageMetadata = {
     displayable: {
       templateName: runConfig.name,

--- a/control-plane/src/modules/workflows/router.ts
+++ b/control-plane/src/modules/workflows/router.ts
@@ -70,12 +70,21 @@ export const runsRouter = initServer().router(
       await auth.canAccess({ cluster: { clusterId } });
       auth.canCreate({ run: true });
 
-      if (body.template) {
-        logger.info("Depreacted `run.template` provided in call to createRun");
-        body.config = body.template;
+      // TODO: Remove once use of deprecated fields is removed
+      if (body.config) {
+        logger.info("Depreacted `run.config` provided in call to createRun");
+        body.configId = body.configId ?? body.config.id;
+        body.input = body.input ?? body.config.input;
       }
 
-      if (!body.initialPrompt && !body.config) {
+      // TODO: Remove once use of deprecated fields is removed
+      if (body.template) {
+        logger.info("Depreacted `run.template` provided in call to createRun");
+        body.configId = body.configId ?? body.template.id;
+        body.input = body.input ?? body.template.input;
+      }
+
+      if (!body.initialPrompt && !body.configId) {
         return {
           status: 400,
           body: {
@@ -124,13 +133,13 @@ export const runsRouter = initServer().router(
         callSummarization: body.callSummarization,
         reasoningTraces: body.reasoningTraces,
 
-        input: body.config?.input,
+        input: body.input,
       };
 
-      const runConfig = body.config
+      const runConfig = body.configId
         ? await getRunConfig({
             clusterId,
-            id: body.config.id,
+            id: body.configId,
           })
         : undefined;
 
@@ -147,6 +156,11 @@ export const runsRouter = initServer().router(
 
         runOptions = merged.options;
       }
+
+      if (runOptions.input) {
+        runOptions.initialPrompt = `${runOptions.initialPrompt}\n\n<DATA>\n${JSON.stringify(runOptions.input, null, 2)}\n</DATA>`;
+      }
+
 
       if (!runOptions.initialPrompt) {
         throw new Error("Failed to construct initialPrompt");


### PR DESCRIPTION
Cleanup `createRun` handling of Run Configurations.

- Deprecate `run.config` object and replace with
- `run.configId`
- `run.input`

`run.input` will be merged with `initialPrompt` _regardless_ of whether or not a config is being used.