### PR TITLE
ci: Run Control Plane tests before deploy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
   test-control-plane:
     runs-on: ubuntu-latest
     needs: [check_changes, build-control-plane]
-    if: ${{ needs.check_changes.outputs.control_plane == 'true' }}
+    if: ${{ needs.check_changes.outputs.control_plane == 'true' || needs.check_changes.outputs.deploy == 'true' }}
     defaults:
       run:
         working-directory: control-plane

--- a/app/README.md
+++ b/app/README.md
@@ -11,7 +11,6 @@ The Inferable Web UI is a user interface for Inferable's control plane. It is op
 
 <img src="https://github.com/inferablehq/inferable/blob/main/app/assets/screenshot.png" alt="Inferable UI" width="100%" style="border-radius: 10px" />
 
-
 ### Local Development
 
 1. Start the control plane:


### PR DESCRIPTION
Currently the deployment doesn't run in only `app` has changed as it relies on `test-control-plane`.