### PR TITLE
fix: Do not copy env file

### DIFF
--- a/data-connector/Dockerfile
+++ b/data-connector/Dockerfile
@@ -12,7 +12,6 @@ RUN npm install
 
 COPY src ./src
 COPY config.json ./config.json
-COPY .env ./
 
 # Expose DEBUG traces
 ENV DEBUG=inferable:*


### PR DESCRIPTION
Do not copy local environment file in the `.env`