### PR TITLE
fix: Introduce assertions for run validation

### DIFF
--- a/sdk-node/package.json
+++ b/sdk-node/package.json
@@ -8,7 +8,7 @@
     "clean": "rm -rf ./bin",
     "prepare": "husky",
     "test": "jest ./src --runInBand --forceExit --setupFiles dotenv/config",
-    "test:dev": "jest ./src --watch --setupFiles dotenv/config"
+    "test:dev": "jest dotenv/config ./src --watch --setupFiles dotenv/config"
   },
   "author": "Inferable, Inc.",
   "license": "MIT",

--- a/sdk-node/package.json
+++ b/sdk-node/package.json
@@ -8,7 +8,7 @@
     "clean": "rm -rf ./bin",
     "prepare": "husky",
     "test": "jest ./src --runInBand --forceExit --setupFiles dotenv/config",
-    "test:dev": "jest dotenv/config ./src --watch --setupFiles dotenv/config"
+    "test:dev": "jest ./src --watch --setupFiles dotenv/config"
   },
   "author": "Inferable, Inc.",
   "license": "MIT",

--- a/sdk-node/src/Inferable.ts
+++ b/sdk-node/src/Inferable.ts
@@ -23,7 +23,7 @@ import {
   validateFunctionSchema,
   validateServiceName,
 } from "./util";
-import { assert, Assertions, assertRun } from "./assertions";
+import { Assertions, assertRun } from "./assertions";
 
 // Custom json formatter
 debug.formatters.J = (json) => {

--- a/sdk-node/src/assertions.test.ts
+++ b/sdk-node/src/assertions.test.ts
@@ -1,0 +1,132 @@
+import { Inferable } from "./inferable";
+import { z } from "zod";
+import assert from "assert";
+import { TEST_ENDPOINT } from "./tests/utils";
+import { TEST_API_SECRET } from "./tests/utils";
+
+describe("assertions", () => {
+  it("should be able to assert a run", async () => {
+    const client = new Inferable({
+      apiSecret: TEST_API_SECRET,
+      endpoint: TEST_ENDPOINT,
+    });
+
+    client.default.register({
+      name: "fetch",
+      func: async ({ url }: { url: string }) => {
+        if (url === "https://news.ycombinator.com/show") {
+          return `<div class="container">
+        <h1>Top Posts</h1>
+        <ul class="post-list">
+            <li class="post-item">
+                <div><a href="https://news.ycombinator.com/item?id=42331270" class="post-title">Banan-OS, an Unix-like operating system written from scratch</a></div>
+                <div class="post-id">ID: 42331270</div>
+            </li>
+            <li class="post-item">
+                <div><a href="https://news.ycombinator.com/item?id=42329071" class="post-title">Replace "hub" by "ingest" in GitHub URLs for a prompt-friendly extract</a></div>
+                <div class="post-id">ID: 42329071</div>
+            </li>
+            <li class="post-item">
+                <div><a href="https://news.ycombinator.com/item?id=42333823" class="post-title">Data Connector – Chat with Your Database and APIs</a></div>
+                <div class="post-id">ID: 42333823</div>
+            </li>
+            <li class="post-item">
+                <div><a href="https://news.ycombinator.com/item?id=42332760" class="post-title">Checkmate, a server and infrastructure monitoring application</a></div>
+                <div class="post-id">ID: 42332760</div>
+            </li>
+            <li class="post-item">
+                <div><a href="https://news.ycombinator.com/item?id=42314905" class="post-title">A 5th order motion planner with PH spline blending, written in Ada</a></div>
+                <div class="post-id">ID: 42314905</div>
+            </li>
+            <li class="post-item">
+                <div><a href="https://news.ycombinator.com/item?id=42332114" class="post-title">JavaFX app recreating the Omegle chat service experience with ChatGPT</a></div>
+                <div class="post-id">ID: 42332114</div>
+            </li>
+            <li class="post-item">
+                <div><a href="https://news.ycombinator.com/item?id=42320032" class="post-title">Outerbase Studio – Open-Source Database GUI</a></div>
+                <div class="post-id">ID: 42320032</div>
+            </li>
+            <li class="post-item">
+                <div><a href="https://news.ycombinator.com/item?id=42317393" class="post-title">I combined spaced repetition with emails so you can remember anything</a></div>
+                <div class="post-id">ID: 42317393</div>
+            </li>
+            <li class="post-item">
+                <div><a href="https://news.ycombinator.com/item?id=42302560" class="post-title">Book and change flights with one email</a></div>
+                <div class="post-id">ID: 42302560</div>
+            </li>
+            <li class="post-item">
+                <div><a href="https://news.ycombinator.com/item?id=42330611" class="post-title">dotnet CMS to build drag-and-drop sites with setup infrastructure</a></div>
+                <div class="post-id">ID: 42330611</div>
+            </li>
+        </ul>
+    </div>`;
+        } else {
+          const randomPastYear = Math.min(
+            2024,
+            Math.floor(Math.random() * 100) + 1900,
+          );
+          return `<div class="container">
+          <h1>Comments</h1>
+          <ul class="comment-list">
+            <li class="comment-item">
+                <div class="comment-text">This is surprising because I observe the same thing in ${randomPastYear}</div>
+            </li>
+          </ul>
+        </div>`;
+        }
+      },
+    });
+
+    await client.default.start();
+
+    const resultSchema = z.object({
+      topPosts: z.array(
+        z.object({
+          id: z.string().describe("The ID of the post"),
+          title: z.string().describe("The title of the post"),
+        }),
+      ),
+      comments: z.array(
+        z.object({
+          commentsPageUrl: z.string().describe("The URL of the comments page"),
+          text: z.string().describe("The text of the comment"),
+        }),
+      ),
+    });
+
+    const run = await client.run({
+      initialPrompt:
+        "Get the top comment for the top 10 posts on Show HN: https://news.ycombinator.com/show",
+      resultSchema: resultSchema,
+    });
+
+    const result = await run.poll<z.infer<typeof resultSchema>>({
+      assertions: [
+        function assertCorrect(result) {
+          const missingComments = result.topPosts.filter(
+            (post) =>
+              !result.comments.some((comment) =>
+                comment.commentsPageUrl.includes(post.id),
+              ),
+          );
+
+          const duplicateComments = result.comments.filter(
+            (comment, index, self) =>
+              self.findIndex((c) => c.text === comment.text) !== index,
+          );
+
+          assert(
+            missingComments.length === 0,
+            `Some posts were missing comments: ${missingComments.map((m) => m.id).join(", ")}`,
+          );
+          assert(
+            duplicateComments.length === 0,
+            `Detected duplicate comments: ${duplicateComments.map((d) => d.text).join(", ")}`,
+          );
+        },
+      ],
+    });
+
+    console.log(result);
+  });
+});

--- a/sdk-node/src/assertions.test.ts
+++ b/sdk-node/src/assertions.test.ts
@@ -1,6 +1,5 @@
 import { Inferable } from "./inferable";
 import { z } from "zod";
-import assert from "assert";
 import { TEST_ENDPOINT } from "./tests/utils";
 import { TEST_API_SECRET } from "./tests/utils";
 
@@ -11,122 +10,41 @@ describe("assertions", () => {
       endpoint: TEST_ENDPOINT,
     });
 
+    let timesRun = 0;
+
     client.default.register({
-      name: "fetch",
-      func: async ({ url }: { url: string }) => {
-        if (url === "https://news.ycombinator.com/show") {
-          return `<div class="container">
-        <h1>Top Posts</h1>
-        <ul class="post-list">
-            <li class="post-item">
-                <div><a href="https://news.ycombinator.com/item?id=42331270" class="post-title">Banan-OS, an Unix-like operating system written from scratch</a></div>
-                <div class="post-id">ID: 42331270</div>
-            </li>
-            <li class="post-item">
-                <div><a href="https://news.ycombinator.com/item?id=42329071" class="post-title">Replace "hub" by "ingest" in GitHub URLs for a prompt-friendly extract</a></div>
-                <div class="post-id">ID: 42329071</div>
-            </li>
-            <li class="post-item">
-                <div><a href="https://news.ycombinator.com/item?id=42333823" class="post-title">Data Connector – Chat with Your Database and APIs</a></div>
-                <div class="post-id">ID: 42333823</div>
-            </li>
-            <li class="post-item">
-                <div><a href="https://news.ycombinator.com/item?id=42332760" class="post-title">Checkmate, a server and infrastructure monitoring application</a></div>
-                <div class="post-id">ID: 42332760</div>
-            </li>
-            <li class="post-item">
-                <div><a href="https://news.ycombinator.com/item?id=42314905" class="post-title">A 5th order motion planner with PH spline blending, written in Ada</a></div>
-                <div class="post-id">ID: 42314905</div>
-            </li>
-            <li class="post-item">
-                <div><a href="https://news.ycombinator.com/item?id=42332114" class="post-title">JavaFX app recreating the Omegle chat service experience with ChatGPT</a></div>
-                <div class="post-id">ID: 42332114</div>
-            </li>
-            <li class="post-item">
-                <div><a href="https://news.ycombinator.com/item?id=42320032" class="post-title">Outerbase Studio – Open-Source Database GUI</a></div>
-                <div class="post-id">ID: 42320032</div>
-            </li>
-            <li class="post-item">
-                <div><a href="https://news.ycombinator.com/item?id=42317393" class="post-title">I combined spaced repetition with emails so you can remember anything</a></div>
-                <div class="post-id">ID: 42317393</div>
-            </li>
-            <li class="post-item">
-                <div><a href="https://news.ycombinator.com/item?id=42302560" class="post-title">Book and change flights with one email</a></div>
-                <div class="post-id">ID: 42302560</div>
-            </li>
-            <li class="post-item">
-                <div><a href="https://news.ycombinator.com/item?id=42330611" class="post-title">dotnet CMS to build drag-and-drop sites with setup infrastructure</a></div>
-                <div class="post-id">ID: 42330611</div>
-            </li>
-        </ul>
-    </div>`;
-        } else {
-          const randomPastYear = Math.min(
-            2024,
-            Math.floor(Math.random() * 100) + 1900,
-          );
-          return `<div class="container">
-          <h1>Comments</h1>
-          <ul class="comment-list">
-            <li class="comment-item">
-                <div class="comment-text">This is surprising because I observe the same thing in ${randomPastYear}</div>
-            </li>
-          </ul>
-        </div>`;
-        }
+      name: "generateRandomNumber",
+      func: async ({ seed }: { seed: number }) => {
+        timesRun++;
+
+        return seed * timesRun;
       },
     });
 
     await client.default.start();
 
     const resultSchema = z.object({
-      topPosts: z.array(
-        z.object({
-          id: z.string().describe("The ID of the post"),
-          title: z.string().describe("The title of the post"),
-        }),
-      ),
-      comments: z.array(
-        z.object({
-          commentsPageUrl: z.string().describe("The URL of the comments page"),
-          text: z.string().describe("The text of the comment"),
-        }),
-      ),
+      result: z.number().describe("The result of the function"),
     });
 
     const run = await client.run({
       initialPrompt:
-        "Get the top comment for the top 10 posts on Show HN: https://news.ycombinator.com/show",
+        "Use the available functions to generate a random number between 0 and 100",
       resultSchema: resultSchema,
     });
 
     const result = await run.poll<z.infer<typeof resultSchema>>({
       assertions: [
         function assertCorrect(result) {
-          const missingComments = result.topPosts.filter(
-            (post) =>
-              !result.comments.some((comment) =>
-                comment.commentsPageUrl.includes(post.id),
-              ),
-          );
-
-          const duplicateComments = result.comments.filter(
-            (comment, index, self) =>
-              self.findIndex((c) => c.text === comment.text) !== index,
-          );
-
-          assert(
-            missingComments.length === 0,
-            `Some posts were missing comments: ${missingComments.map((m) => m.id).join(", ")}`,
-          );
-          assert(
-            duplicateComments.length === 0,
-            `Detected duplicate comments: ${duplicateComments.map((d) => d.text).join(", ")}`,
-          );
+          if (timesRun === 1) {
+            throw new Error(
+              `The result ${result.result} is unacceptable. Try again with a different seed.`,
+            );
+          }
         },
       ],
     });
 
-    console.log(result);
+    expect(result.result).toBeGreaterThan(0);
   });
 });

--- a/sdk-node/src/assertions.test.ts
+++ b/sdk-node/src/assertions.test.ts
@@ -1,4 +1,4 @@
-import { Inferable } from "./inferable";
+import { Inferable } from "./Inferable";
 import { z } from "zod";
 import { TEST_ENDPOINT } from "./tests/utils";
 import { TEST_API_SECRET } from "./tests/utils";

--- a/sdk-node/src/assertions.ts
+++ b/sdk-node/src/assertions.ts
@@ -1,0 +1,58 @@
+import { createApiClient } from "./create-client";
+
+type FunctionCall = {
+  service: string;
+  function: string;
+};
+
+type AssertionFunction<T> = (
+  result: T,
+  functionCalls: FunctionCall[],
+) => void | Promise<void>;
+
+export type Assertions<T> = AssertionFunction<T>[];
+
+export async function assertRun<T>({
+  clusterId,
+  runId,
+  client,
+  result,
+  functionCalls,
+  assertions,
+}: {
+  clusterId: string;
+  runId: string;
+  client: ReturnType<typeof createApiClient>;
+  result: T;
+  functionCalls: FunctionCall[];
+  assertions: Assertions<T>;
+}): Promise<{
+  assertionsPassed: boolean;
+}> {
+  const results = await Promise.allSettled(
+    assertions.map((a) => a(result, functionCalls)),
+  );
+
+  const hasRejections = results.some((r) => r.status === "rejected");
+
+  if (hasRejections) {
+    await client.createMessage({
+      body: {
+        message: `You attempted to return a result, but I have determined the result is possibly incorrect due to failing assertions.`,
+        type: "human",
+      },
+      params: {
+        clusterId,
+        runId,
+      },
+    });
+
+    return {
+      assertionsPassed: false,
+    };
+  }
+
+  return {
+    assertionsPassed: true,
+  };
+}


### PR DESCRIPTION
- Assertions allow guardrails that cannot be violated by the LLM by providing a function that can inspect the result and throw an error if it's not correct.
- Additional context can be provided to the assertion function to help it make a better decision.
- This is undocumented.