### PR TITLE
feat: Retry model provider throttling

### DIFF
--- a/control-plane/src/modules/models/index.test.ts
+++ b/control-plane/src/modules/models/index.test.ts
@@ -53,6 +53,7 @@ describe("buildModel", () => {
       });
     });
 
+
     it("should not retry other errors", async () => {
       const error = new Error("");
       mockCreate.mockImplementationOnce(() => {
@@ -77,5 +78,48 @@ describe("buildModel", () => {
         identifier: "claude-3-haiku",
       });
     });
+
+    it.skip("should throw after exhausting retries", async () => {
+      mockCreate.mockImplementation(() => {
+        throw new RetryableError("");
+      });
+
+      const model = buildModel({
+        identifier: "claude-3-haiku",
+      });
+
+      await expect(
+        () => model.call({
+          messages: [],
+        })
+      ).rejects.toThrow(RetryableError);
+
+      expect(getRouting).toHaveBeenCalledTimes(6);
+
+      expect(getRouting).toHaveBeenCalledWith({
+        index: 0,
+        identifier: "claude-3-haiku",
+      });
+
+      expect(getRouting).toHaveBeenCalledWith({
+        index: 1,
+        identifier: "claude-3-haiku",
+      });
+
+      expect(getRouting).toHaveBeenCalledWith({
+        index: 2,
+        identifier: "claude-3-haiku",
+      });
+
+      expect(getRouting).toHaveBeenCalledWith({
+        index: 3,
+        identifier: "claude-3-haiku",
+      });
+
+      expect(getRouting).toHaveBeenCalledWith({
+        index: 4,
+        identifier: "claude-3-haiku",
+      });
+    }, 60_000);
   });
 });

--- a/control-plane/src/utilities/errors.test.ts
+++ b/control-plane/src/utilities/errors.test.ts
@@ -1,0 +1,14 @@
+import { isRetryableError, RetryableError } from "./errors";
+import { RateLimitError } from "@anthropic-ai/sdk";
+
+describe("isRetryableError", () => {
+  it("should return true for retryable errors", async () => {
+    expect(isRetryableError(new Error())).toBe(false);
+
+    expect(isRetryableError(new RateLimitError(429, new Error(), "", {}))).toBe(true);
+    expect(isRetryableError(new RetryableError(""))).toBe(true);
+
+
+    expect(isRetryableError(new Error("429 Too many requests, please wait before trying again."))).toBe(true);
+  });
+})


### PR DESCRIPTION
Ensure that Bedrock / Anthropic rate limiting exceptions are handled with retry logic.