### PR TITLE
chore: Cache customer auth context

### DIFF
--- a/control-plane/src/modules/auth/api-secret.ts
+++ b/control-plane/src/modules/auth/api-secret.ts
@@ -1,20 +1,16 @@
 import * as data from "../data";
 import { eq, and, isNull } from "drizzle-orm";
-import { createHash, randomBytes } from "crypto";
+import { randomBytes } from "crypto";
 import { logger } from "../observability/logger";
-import { createCache } from "../../utilities/cache";
+import { createCache, hashFromSecret } from "../../utilities/cache";
 
-const authContextCache = createCache<{
+const apiKeyContextCache = createCache<{
   clusterId: string;
   id: string;
   organizationId: string;
 }>(
-  Symbol("authContextCach"),
+  Symbol("apiKeyContextCache"),
 );
-
-const hashFromSecret = (secret: string): string => {
-  return createHash("sha256").update(secret).digest("hex");
-};
 
 export const isApiSecret = (authorization: string): boolean =>
   authorization.startsWith("sk_");
@@ -26,7 +22,7 @@ export const verifyApiKey = async (
 > => {
   const secretHash = hashFromSecret(secret);
 
-  const cached = await authContextCache.get(secretHash);
+  const cached = await apiKeyContextCache.get(secretHash);
 
   if (cached) {
     return cached;
@@ -60,7 +56,7 @@ export const verifyApiKey = async (
     return undefined;
   }
 
-  await authContextCache.set(secretHash, {
+  await apiKeyContextCache.set(secretHash, {
     clusterId: result.clusterId,
     id: result.id,
     organizationId: result.organizationId,

--- a/control-plane/src/modules/auth/auth.ts
+++ b/control-plane/src/modules/auth/auth.ts
@@ -373,6 +373,7 @@ export const extractCustomerAuthState = async (
   if (!cluster.enable_customer_auth) {
     throw new AuthenticationError(
       "Customer auth is not enabled for this cluster",
+      "https://docs.inferable.ai/pages/auth#customer-provided-secrets"
     );
   }
 

--- a/control-plane/src/modules/auth/customer-auth.ts
+++ b/control-plane/src/modules/auth/customer-auth.ts
@@ -89,14 +89,17 @@ export const verifyCustomerProvidedAuth = async ({
     if (e instanceof JobPollTimeoutError) {
       throw new AuthenticationError(
         `Call to ${VERIFY_FUNCTION_ID} did not complete in time`,
+        "https://docs.inferable.ai/pages/auth#handlecustomerauth"
       );
     }
 
-    if (e instanceof InvalidJobArgumentsError) {
+    if (e instanceof Error) {
       throw new AuthenticationError(
-        `Could not find ${VERIFY_FUNCTION_ID} registration`,
+      `Call to ${VERIFY_FUNCTION_ID} failed with error: ${e.message}`,
+        "https://docs.inferable.ai/pages/auth#handlecustomerauth"
       );
     }
+
     throw e;
   }
 };

--- a/control-plane/src/utilities/cache.ts
+++ b/control-plane/src/utilities/cache.ts
@@ -1,3 +1,4 @@
+import { createHash } from "crypto";
 import NodeCache from "node-cache";
 import { redisClient } from "../modules/redis";
 
@@ -37,3 +38,8 @@ export const createCache = <T>(namespace: symbol) => {
 // const cache = createCache(Symbol("cache"));
 // cache.set("key", "value");
 // const value = cache.get("key");
+
+export const hashFromSecret = (secret: string): string => {
+  return createHash("sha256").update(secret).digest("hex");
+};
+


### PR DESCRIPTION
Calling the `handleCustomerAuth` function during a request is expensive, cache the value for 5 minutes.