### PR TITLE
ci: Remove cancel in progress

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,6 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
   check_changes:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,9 @@ on:
     types:
       - completed
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   check_changes:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Disable GH actions `cancel-in-progress` now that we have multiple projects in the repo.

Cancelling a build for one the publish packages means that the change won't be published.
https://github.com/inferablehq/inferable/actions/runs/12268350515