### PR TITLE
fix: Remove duplicate update notifier

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -4,7 +4,6 @@ import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import updateNotifier from "simple-update-notifier";
 import pkg from "../package.json";
-
 import { Auth } from "./commands/auth";
 import { Cli } from "./commands/cli";
 import { Clusters } from "./commands/clusters";
@@ -13,16 +12,13 @@ import { Bootstrap } from "./commands/bootstrap";
 import { Runs } from "./commands/runs";
 import { Generate } from "./commands/generate";
 import { AppOpen } from "./commands/open";
-import packageJson from "../package.json";
 
 // Check for updates and notify
-const notifier = updateNotifier({
-  pkg,
+updateNotifier({ 
+  pkg: pkg, 
   updateCheckInterval: 1000 * 60 * 60 * 24,
-  shouldNotifyInNpmScript: true,
+  shouldNotifyInNpmScript: true, 
 });
-
-updateNotifier({ pkg: packageJson });
 
 const cli = yargs(hideBin(process.argv))
   .scriptName("@inferable/cli")


### PR DESCRIPTION
Bug: When starting the CLI the notification to update the CLI appears twice.