### PR TITLE
feat: Slack Run triggering

### DIFF
--- a/control-plane/package-lock.json
+++ b/control-plane/package-lock.json
@@ -18,6 +18,7 @@
         "@langchain/cohere": "^0.3.1",
         "@langchain/langgraph": "^0.1.9",
         "@openapi-contrib/openapi-schema-to-json-schema": "^5.1.0",
+        "@slack/bolt": "^4.1.1",
         "@toolhouseai/sdk": "^1.0.4",
         "@ts-rest/core": "^3.27.0",
         "@ts-rest/fastify": "3.45.2",
@@ -10244,6 +10245,154 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@slack/bolt": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@slack/bolt/-/bolt-4.1.1.tgz",
+      "integrity": "sha512-Sc8QUnEHCPgRlwrMxmvOl4Vhr/7ZBDXvLR0ir6TO+W5MaDtPsrmWLxqLmb+OhCGSjDp3d4AxO6jdFlC3yNKtsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@slack/logger": "^4.0.0",
+        "@slack/oauth": "^3",
+        "@slack/socket-mode": "^2.0.2",
+        "@slack/types": "^2.13.0",
+        "@slack/web-api": "^7",
+        "@types/express": "^4.17.21",
+        "axios": "^1.7.4",
+        "express": "^5.0.0",
+        "path-to-regexp": "^8.1.0",
+        "raw-body": "^3",
+        "tsscmp": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=8.6.0"
+      }
+    },
+    "node_modules/@slack/bolt/node_modules/@types/express": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@slack/bolt/node_modules/@types/express-serve-static-core": {
+      "version": "4.19.6",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
+      "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@slack/logger": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-4.0.0.tgz",
+      "integrity": "sha512-Wz7QYfPAlG/DR+DfABddUZeNgoeY7d1J39OCR2jR+v7VBsB8ezulDK5szTnDDPDwLH5IWhLvXIHlCFZV7MSKgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=18.0.0"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
+    "node_modules/@slack/oauth": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@slack/oauth/-/oauth-3.0.2.tgz",
+      "integrity": "sha512-MdPS8AP9n3u/hBeqRFu+waArJLD/q+wOSZ48ktMTwxQLc6HJyaWPf8soqAyS/b0D6IlvI5TxAdyRyyv3wQ5IVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@slack/logger": "^4",
+        "@slack/web-api": "^7.8.0",
+        "@types/jsonwebtoken": "^9",
+        "@types/node": ">=18",
+        "jsonwebtoken": "^9",
+        "lodash.isstring": "^4"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=8.6.0"
+      }
+    },
+    "node_modules/@slack/socket-mode": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@slack/socket-mode/-/socket-mode-2.0.3.tgz",
+      "integrity": "sha512-aY1AhQd3HAgxLYC2Mz47dXtW6asjyYp8bJ24MWalg+qFWPaXj8VBYi+5w3rfGqBW5IxlIhs3vJTEQtIBrqQf5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@slack/logger": "^4",
+        "@slack/web-api": "^7.8.0",
+        "@types/node": ">=18",
+        "@types/ws": "^8",
+        "eventemitter3": "^5",
+        "ws": "^8"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
+    "node_modules/@slack/socket-mode/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/@slack/types": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.14.0.tgz",
+      "integrity": "sha512-n0EGm7ENQRxlXbgKSrQZL69grzg1gHLAVd+GlRVQJ1NSORo0FrApR7wql/gaKdu2n4TO83Sq/AmeUOqD60aXUA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0",
+        "npm": ">= 6.12.0"
+      }
+    },
+    "node_modules/@slack/web-api": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.8.0.tgz",
+      "integrity": "sha512-d4SdG+6UmGdzWw38a4sN3lF/nTEzsDxhzU13wm10ejOpPehtmRoqBKnPztQUfFiWbNvSb4czkWYJD4kt+5+Fuw==",
+      "license": "MIT",
+      "dependencies": {
+        "@slack/logger": "^4.0.0",
+        "@slack/types": "^2.9.0",
+        "@types/node": ">=18.0.0",
+        "@types/retry": "0.12.0",
+        "axios": "^1.7.8",
+        "eventemitter3": "^5.0.1",
+        "form-data": "^4.0.0",
+        "is-electron": "2.2.2",
+        "is-stream": "^2",
+        "p-queue": "^6",
+        "p-retry": "^4",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
+    "node_modules/@slack/web-api/node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/@slack/web-api/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
     "node_modules/@smithy/abort-controller": {
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.8.tgz",
@@ -12769,6 +12918,15 @@
       "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
       "license": "MIT"
     },
+    "node_modules/@types/ws": {
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.13.tgz",
+      "integrity": "sha512-osM/gWBTPKgHV8XkTunnegTRIsvF6owmf5w+JtAfOw472dptdm0dlGv4xCt6GwQRcC2XVOvvRE/0bAoQcL2QkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
@@ -13125,6 +13283,40 @@
       "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
       "license": "MIT"
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-db": {
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.53.0.tgz",
+      "integrity": "sha512-oHlN/w+3MQ3rba9rqFr6V/ypF10LSkdwUysQL7GkXoTgIWeV+tcXGA852TBxH+gsh8UWoyhR1hKcoMJTuWflpg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-types": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.0.tgz",
+      "integrity": "sha512-XqoSHeCGjVClAmoGFG3lVFqQFRIrTVw2OH3axRqAcfaw+gHWIfnASS92AV+Rl/mk0MupgZTRHQOjxY6YVnzK5w==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.53.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.14.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
@@ -13379,6 +13571,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/array-flatten": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
+      "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA==",
+      "license": "MIT"
     },
     "node_modules/array-union": {
       "version": "2.1.0",
@@ -13684,6 +13882,79 @@
         "node": ">= 6"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.0.2.tgz",
+      "integrity": "sha512-SNMk0OONlQ01uk8EPeiBvTW7W4ovpL5b1O3t1sjpPgfxOQ6BqQJ6XjxinDPR79Z6HdcD5zBBwr5ssiTlgdNztQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "3.1.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.5.2",
+        "on-finished": "2.4.1",
+        "qs": "6.13.0",
+        "raw-body": "^3.0.0",
+        "type-is": "~1.6.18"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/body-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser/node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/body-parser/node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
@@ -13788,6 +14059,15 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/call-bind": {
       "version": "1.0.7",
@@ -14130,6 +14410,27 @@
       "integrity": "sha512-w+JSDZS7XML43Xnwo2x5O5vxB0ID7T5BdqDtyqT6uiCAX2kZAgcWxNaGqT97tZfSHzfOcvrfsDAodKcJ3UvnXQ==",
       "license": "MIT"
     },
+    "node_modules/content-disposition": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -14143,6 +14444,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
       }
     },
     "node_modules/core-js-compat": {
@@ -14338,11 +14648,30 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/dereference-json-schema": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/dereference-json-schema/-/dereference-json-schema-0.2.1.tgz",
       "integrity": "sha512-uzJsrg225owJyRQ8FNTPHIuBOdSzIZlHhss9u6W8mp7jJldHqGuLv9cULagP/E26QVJDnjtG8U7Dw139mM1ydA==",
       "license": "MIT"
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
     },
     "node_modules/detect-newline": {
       "version": "3.1.0",
@@ -14568,6 +14897,12 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.66",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.66.tgz",
@@ -14597,6 +14932,15 @@
       "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
       "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/entities": {
       "version": "4.5.0",
@@ -14708,6 +15052,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -15093,6 +15443,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -15171,6 +15530,117 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.0.1.tgz",
+      "integrity": "sha512-ORF7g6qGnD+YtUG9yx4DFoqCShNMmUKiXuT5oWMHiOvt/4WFbHC6yCwQMTSBMno7AqntNCAzzcnnjowRkTL9eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.0.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "~1.0.4",
+        "cookie": "0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "4.3.6",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "^2.0.0",
+        "fresh": "2.0.0",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "methods": "~1.1.2",
+        "mime-types": "^3.0.0",
+        "on-finished": "2.4.1",
+        "once": "1.4.0",
+        "parseurl": "~1.3.3",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.13.0",
+        "range-parser": "~1.2.1",
+        "router": "^2.0.0",
+        "safe-buffer": "5.2.1",
+        "send": "^1.1.0",
+        "serve-static": "^2.1.0",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "^2.0.0",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/debug": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.53.0.tgz",
+      "integrity": "sha512-oHlN/w+3MQ3rba9rqFr6V/ypF10LSkdwUysQL7GkXoTgIWeV+tcXGA852TBxH+gsh8UWoyhR1hKcoMJTuWflpg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.0.tgz",
+      "integrity": "sha512-XqoSHeCGjVClAmoGFG3lVFqQFRIrTVw2OH3axRqAcfaw+gHWIfnASS92AV+Rl/mk0MupgZTRHQOjxY6YVnzK5w==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.53.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "license": "MIT"
+    },
+    "node_modules/express/node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/extend": {
@@ -15408,6 +15878,48 @@
         "node": ">=8"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.0.0.tgz",
+      "integrity": "sha512-MX6Zo2adDViYh+GcxxB1dpO43eypOGUOL12rLCOTMQv/DfIbpSJUy4oQIIZhVZkH9e+bZWKMon0XHFEju16tkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/finalhandler/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/finalhandler/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
     "node_modules/find": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/find/-/find-0.2.9.tgz",
@@ -15621,6 +16133,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/fs.realpath": {
@@ -15960,6 +16481,22 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "license": "MIT"
     },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
@@ -15989,6 +16526,18 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.2.tgz",
+      "integrity": "sha512-kERHXvpSaB4aU3eANwidg79K8FlrN77m8G9V+0vOR3HYaRifrlwMEpT7ZBJqLSEIHnEgJTHcWK82wwLwwKwtag==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ieee754": {
@@ -16165,6 +16714,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-electron": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+      "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==",
+      "license": "MIT"
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -16234,6 +16789,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
     },
     "node_modules/is-reference": {
       "version": "3.0.3",
@@ -17869,6 +18430,27 @@
         "is-buffer": "~1.1.6"
       }
     },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -17883,6 +18465,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/micromatch": {
@@ -18019,6 +18610,15 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/node-cache": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
@@ -18140,6 +18740,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/once": {
@@ -18463,6 +19075,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -18495,6 +19116,15 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -19089,6 +19719,42 @@
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
     },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
+      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.6.3",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -19452,6 +20118,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/router": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.0.0.tgz",
+      "integrity": "sha512-dIM5zVoG8xhC6rnSN8uoAgFARwTE7BQs8YwHEvK0VCmfxQXMaOuA1uiR1IPwsW7JyK5iTt7Od/TC9StasS2NPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "array-flatten": "3.0.0",
+        "is-promise": "4.0.0",
+        "methods": "~1.1.2",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "^8.0.0",
+        "setprototypeof": "1.2.0",
+        "utils-merge": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -19520,6 +20204,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/secure-json-parse": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
@@ -19533,6 +20223,53 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.1.0.tgz",
+      "integrity": "sha512-v67WcEouB5GxbTWL/4NeToqcZiAWEq90N888fczVArY8A79J0L4FD7vj5hm3eUMua5EpoQ59wa/oovY6TLvRUA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "destroy": "^1.2.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^0.5.2",
+        "http-errors": "^2.0.0",
+        "mime-types": "^2.1.35",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/send/node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.1.0.tgz",
+      "integrity": "sha512-A3We5UfEjG8Z7VkDv6uItWw6HY2bBSBJT1KtVESn6EOoOr2jAxNhxWCLY3jDE2WcuHXByWju74ck3ZgLwL8xmA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/set-cookie-parser": {
@@ -19557,6 +20294,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -19769,6 +20512,15 @@
       "license": "MIT",
       "dependencies": {
         "escodegen": "^1.8.1"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/string_decoder": {
@@ -20046,6 +20798,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -20139,6 +20900,15 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
+      }
     },
     "node_modules/tsx": {
       "version": "4.19.2",
@@ -20626,6 +21396,41 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.0.tgz",
+      "integrity": "sha512-gd0sGezQYCbWSbkZr75mln4YBidWUN60+devscpLF5mtRDUpiaTvKpBNrdaCvel1NdR2k6vclXybU5fBd2i+nw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-db": {
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.53.0.tgz",
+      "integrity": "sha512-oHlN/w+3MQ3rba9rqFr6V/ypF10LSkdwUysQL7GkXoTgIWeV+tcXGA852TBxH+gsh8UWoyhR1hKcoMJTuWflpg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-types": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.0.tgz",
+      "integrity": "sha512-XqoSHeCGjVClAmoGFG3lVFqQFRIrTVw2OH3axRqAcfaw+gHWIfnASS92AV+Rl/mk0MupgZTRHQOjxY6YVnzK5w==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.53.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
@@ -20716,6 +21521,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
@@ -20778,6 +21592,15 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/uuid": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
@@ -20810,6 +21633,15 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/vue": {
@@ -21032,6 +21864,27 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xtend": {

--- a/control-plane/package.json
+++ b/control-plane/package.json
@@ -28,6 +28,7 @@
     "@langchain/cohere": "^0.3.1",
     "@langchain/langgraph": "^0.1.9",
     "@openapi-contrib/openapi-schema-to-json-schema": "^5.1.0",
+    "@slack/bolt": "^4.1.1",
     "@toolhouseai/sdk": "^1.0.4",
     "@ts-rest/core": "^3.27.0",
     "@ts-rest/fastify": "3.45.2",

--- a/control-plane/src/index.ts
+++ b/control-plane/src/index.ts
@@ -15,6 +15,7 @@ import * as externalCalls from "./modules/jobs/external";
 import * as models from "./modules/models/routing";
 import { logContext, logger } from "./modules/observability/logger";
 import * as workflows from "./modules/workflows/workflows";
+import * as slack from "./modules/slack";
 import { hdx } from "./modules/observability/hyperdx";
 import { pg } from "./modules/data";
 import { addAttributes } from "./modules/observability/tracer";
@@ -22,7 +23,7 @@ import { flagsmith } from "./modules/flagsmith";
 import { runMigrations } from "./utilities/migrate";
 import { customerTelemetry } from "./modules/customer-telemetry";
 
-const app = fastify({
+export const app = fastify({
   logger: env.ENABLE_FASTIFY_LOGGER,
 });
 
@@ -148,6 +149,7 @@ const startTime = Date.now();
     customerTelemetry.start(),
     toolhouse.start(),
     externalCalls.start(),
+    slack.start(app),
     ...(env.EE_DEPLOYMENT
       ? [
           flagsmith?.getEnvironmentFlags(),
@@ -192,6 +194,7 @@ process.on("SIGTERM", async () => {
     redis.stop(),
     customerTelemetry.stop(),
     externalCalls.stop(),
+    slack.stop(),
   ]);
 
   logger.info("Shutdown complete");

--- a/control-plane/src/index.ts
+++ b/control-plane/src/index.ts
@@ -23,7 +23,7 @@ import { flagsmith } from "./modules/flagsmith";
 import { runMigrations } from "./utilities/migrate";
 import { customerTelemetry } from "./modules/customer-telemetry";
 
-export const app = fastify({
+const app = fastify({
   logger: env.ENABLE_FASTIFY_LOGGER,
 });
 

--- a/control-plane/src/modules/slack/index.ts
+++ b/control-plane/src/modules/slack/index.ts
@@ -1,40 +1,101 @@
-import { App } from '@slack/bolt';
+import { App, KnownEventFromType, webApi } from '@slack/bolt';
 import { FastifySlackReceiver } from './receiver';
 import { env } from '../../utilities/env';
 import { FastifyInstance } from 'fastify';
 import { logger } from '../observability/logger';
+import { getRunsByMetadata } from '../workflows/metadata';
+import { addMessageAndResume, createRunWithMessage, Run } from '../workflows/workflows';
+import { AuthenticationError } from '../../utilities/errors';
+import { ulid } from 'ulid';
 
 let app: App | undefined;
 
+const THREAD_META_KEY = "stripeThreadTs";
+const CHANNEL_META_KEY = "stripeChannel";
+
+type MessageEvent = {
+  event: KnownEventFromType<'message'>,
+  client: webApi.WebClient
+  clusterId: string
+}
+
 export const start = async (fastify: FastifyInstance) => {
+  const SLACK_CLUSTER_ID = env.SLACK_CLUSTER_ID
+  const SLACK_BOT_TOKEN = env.SLACK_BOT_TOKEN
+  const SLACK_SIGNING_SECRET = env.SLACK_SIGNING_SECRET
+
+  if (
+    !SLACK_CLUSTER_ID ||
+    !SLACK_BOT_TOKEN ||
+    !SLACK_SIGNING_SECRET
+  ) {
+    logger.info("Missing Slack environment variables. Skipping Slack integration.");
+    return
+  }
+
   app = new App({
     token: env.SLACK_BOT_TOKEN,
     receiver: new FastifySlackReceiver({
-      signingSecret: env.SLACK_SIGNING_SECRET,
+      signingSecret: SLACK_SIGNING_SECRET,
       path: '/triggers/slack',
       fastify,
     })
   });
 
-  app.event('app_mention', async ({ event }) => {
-    logger.info("Received app_mention event. Skipping.", event);
-  });
-
   // Event listener for direct messages
   app.event('message', async ({ event, client }) => {
     logger.info("Received message event. Responding.", event);
+
+    if (isBotMessage(event)) {
+      logger.info("Received message from bot. Ignoring.", event);
+      return
+    }
+
+    if (!isDirectMessage(event)) {
+      logger.info("Received message from channel. Ignoring.", event);
+      return
+    }
+
     try {
-      if (event.channel_type === 'im' && event.subtype !== 'bot_message') {
-        // Respond to the direct message
-        await client.chat.postMessage({
-          channel: event.channel,
-          text: `Thanks for tagging me! Let's discuss here.`,
-          thread_ts: event.ts, // Use the timestamp of the original message to create a thread
+      await authenticateUser(event, client);
+
+      if (hasThread(event)) {
+        const [run] = await getRunsByMetadata({
+          clusterId: SLACK_CLUSTER_ID,
+          key: THREAD_META_KEY,
+          value: event.thread_ts,
+          limit: 1,
         });
 
+        if (run)  {
+          await handleExistingThread({
+            event,
+            client,
+            run,
+            clusterId: SLACK_CLUSTER_ID
+          });
+          return
+        }
       }
+
+      await handleNewThread({
+        event,
+        client,
+        clusterId: SLACK_CLUSTER_ID
+      });
+
     } catch (error) {
-      logger.error('Error responding to DM', { error });
+
+      if (error instanceof AuthenticationError) {
+        client.chat.postMessage({
+          thread_ts: event.ts,
+          channel: event.channel,
+          text: "Sorry, I couldn't authenticate you. Please ensure you have an Inferable account with the same email as your Slack account."
+        })
+        return
+      }
+
+      logger.error('Error responding to Direct Message', { error });
     }
   });
 
@@ -42,3 +103,89 @@ export const start = async (fastify: FastifyInstance) => {
 }
 
 export const stop = async () => await app?.stop();
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const hasThread = (e: any): e is { thread_ts: string } => {
+  return typeof e?.thread_ts === 'string';
+}
+
+const hasUser = (e: any): e is { user: string } => {
+  return typeof e?.user === 'string';
+}
+
+const isDirectMessage = (e: KnownEventFromType<'message'>): boolean => {
+  return e.channel_type === 'im';
+}
+
+const isBotMessage = (e: KnownEventFromType<'message'>): boolean => {
+  return e.subtype === 'bot_message';
+}
+
+const handleNewThread = async ({
+  event,
+  client,
+  clusterId
+}: MessageEvent) => {
+
+  if ('text' in event && event.text) {
+    const run = await createRunWithMessage({
+      clusterId,
+      message: event.text,
+      type: "human",
+      metadata: {
+        [THREAD_META_KEY]: event.ts,
+        [CHANNEL_META_KEY]: event.channel
+      },
+    });
+
+    client.chat.postMessage({
+      thread_ts: event.ts,
+      channel: event.channel,
+      mrkdwn: true,
+      text: `On it. I will get back to you soon.\nRun ID: <${env.APP_ORIGIN}/clusters/${clusterId}/runs/${run.id}|${run.id}>`,
+    });
+    return;
+  }
+
+  throw new Error("Event had no text");
+}
+
+const handleExistingThread = async ({
+  event,
+  run,
+} : MessageEvent & { run: Run }) => {
+  if ('text' in event && event.text) {
+    await addMessageAndResume({
+      id: ulid(),
+      clusterId: run.clusterId,
+      runId: run.id,
+      message: event.text,
+      type: "human",
+    })
+    return
+  }
+
+  throw new Error("Event had no text")
+}
+
+const authenticateUser = async (event: KnownEventFromType<'message'>, client: webApi.WebClient) => {
+  if (hasUser(event)) {
+    const user = await client.users.info({
+      user: event.user,
+      token: env.SLACK_BOT_TOKEN
+    })
+
+    const confirmed = user.user?.is_email_confirmed
+    const email = user.user?.profile?.email
+
+    if (!confirmed || !email) {
+      throw new AuthenticationError('Could not authenticate Slack user')
+    }
+
+    // TODO: Verify user in Clerk
+    return
+  }
+
+  throw new Error("Event had no user")
+}
+

--- a/control-plane/src/modules/slack/index.ts
+++ b/control-plane/src/modules/slack/index.ts
@@ -11,22 +11,20 @@ export const start = async (fastify: FastifyInstance) => {
     token: env.SLACK_BOT_TOKEN,
     receiver: new FastifySlackReceiver({
       signingSecret: env.SLACK_SIGNING_SECRET,
+      path: '/triggers/slack',
       fastify,
     })
   });
 
-
-  app.event('app_mention', async ({ event, client, say }) => {
+  app.event('app_mention', async ({ event }) => {
     logger.info("Received app_mention event. Skipping.", event);
   });
 
   // Event listener for direct messages
-  app.event('message', async ({ event, client, say }) => {
+  app.event('message', async ({ event, client }) => {
     logger.info("Received message event. Responding.", event);
     try {
       if (event.channel_type === 'im' && event.subtype !== 'bot_message') {
-
-        await say(`Hi there! I'm Inferable, your friendly AI assistant. How can I help you today?`);
         // Respond to the direct message
         await client.chat.postMessage({
           channel: event.channel,

--- a/control-plane/src/modules/slack/index.ts
+++ b/control-plane/src/modules/slack/index.ts
@@ -1,0 +1,46 @@
+import { App } from '@slack/bolt';
+import { FastifySlackReceiver } from './receiver';
+import { env } from '../../utilities/env';
+import { FastifyInstance } from 'fastify';
+import { logger } from '../observability/logger';
+
+let app: App | undefined;
+
+export const start = async (fastify: FastifyInstance) => {
+  app = new App({
+    token: env.SLACK_BOT_TOKEN,
+    receiver: new FastifySlackReceiver({
+      signingSecret: env.SLACK_SIGNING_SECRET,
+      fastify,
+    })
+  });
+
+
+  app.event('app_mention', async ({ event, client, say }) => {
+    logger.info("Received app_mention event. Skipping.", event);
+  });
+
+  // Event listener for direct messages
+  app.event('message', async ({ event, client, say }) => {
+    logger.info("Received message event. Responding.", event);
+    try {
+      if (event.channel_type === 'im' && event.subtype !== 'bot_message') {
+
+        await say(`Hi there! I'm Inferable, your friendly AI assistant. How can I help you today?`);
+        // Respond to the direct message
+        await client.chat.postMessage({
+          channel: event.channel,
+          text: `Thanks for tagging me! Let's discuss here.`,
+          thread_ts: event.ts, // Use the timestamp of the original message to create a thread
+        });
+
+      }
+    } catch (error) {
+      logger.error('Error responding to DM', { error });
+    }
+  });
+
+  await app.start();
+}
+
+export const stop = async () => await app?.stop();

--- a/control-plane/src/modules/slack/receiver.ts
+++ b/control-plane/src/modules/slack/receiver.ts
@@ -1,0 +1,162 @@
+import {
+  App,
+  Receiver,
+  ReceiverEvent,
+  BufferedIncomingMessage,
+  HTTPModuleFunctions as boltHelpers,
+  HTTPResponseAck,
+  Logger,
+  LogLevel,
+} from '@slack/bolt'
+import { FastifyInstance } from 'fastify';
+import { createServer } from 'http';
+import { logger } from '../observability/logger';
+
+const slackLogger: Logger = {
+  debug: (message: string) => logger.debug(message),
+  error: (message: string) => logger.error(message),
+  info: (message: string) => logger.info(message),
+  warn: (message: string) => logger.warn(message),
+  getLevel: () => LogLevel.INFO,
+  setLevel: (level: string) => void 0,
+  setName: (name: string) => void 0,
+}
+
+export class FastifySlackReceiver implements Receiver {
+  fastify: FastifyInstance;
+  app?: App;
+  path: string
+  signingSecret: string
+
+  constructor({
+    path = '/slack/events',
+    fastify,
+    signingSecret,
+  }: {
+      path?: string
+      fastify: FastifyInstance
+      signingSecret: string
+    }) {
+    this.fastify = fastify;
+    this.path = path
+    this.signingSecret = signingSecret
+  }
+
+  init(app: App) {
+    this.app = app;
+  }
+
+  start() {
+    logger.info("Starting Slack receiver")
+
+    return new Promise((resolve, reject) => {
+      try {
+        // Bind request handler
+        this.fastify.post(this.path, (request, reply) => this.requestHandler(request, reply));
+        resolve(void 0);
+      } catch (error) {
+        reject(error);
+      }
+    });
+  }
+
+  stop() {
+    logger.info("Stopping Slack receiver")
+
+    return new Promise((resolve, reject) => {
+      this.fastify.server.close((err) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve(void 0);
+      })
+    })
+  }
+
+  async requestHandler(request: any, response: any) {
+    const req = request.raw;
+    const res = response.raw;
+    try {
+      // Verify authenticity
+      let bufferedReq: BufferedIncomingMessage;
+      try {
+        const bodyString = typeof request.body === "string"
+            ? request.body
+            : JSON.stringify(request.body);
+
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (req as any).rawBody = Buffer.from(bodyString);
+
+        bufferedReq = await boltHelpers.parseAndVerifyHTTPRequest(
+          {
+            enabled: true,
+            signingSecret: this.signingSecret,
+          },
+          req,
+        );
+      } catch (error) {
+        logger.warn("Failed to parse and verify Slack request", {
+          error,
+        });
+        boltHelpers.buildNoBodyResponse(res, 401);
+        return;
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let body: any;
+      try {
+        body = boltHelpers.parseHTTPRequestBody(bufferedReq);
+      } catch (error) {
+        logger.warn("Malformed Slack request", {
+          error,
+        });
+        boltHelpers.buildNoBodyResponse(res, 400);
+        return;
+      }
+
+      if (body.ssl_check) {
+        boltHelpers.buildSSLCheckResponse(res);
+        return;
+      }
+
+      if (body.type === 'url_verification') {
+        boltHelpers.buildUrlVerificationResponse(res, body);
+        return;
+      }
+
+      const ack = new HTTPResponseAck({
+        logger: slackLogger,
+        processBeforeResponse: false,
+        unhandledRequestHandler: () => {
+          logger.warn("Unhandled Slack request");
+        },
+        httpRequest: bufferedReq,
+        httpResponse: res,
+      });
+
+      const event: ReceiverEvent = {
+        body,
+        ack: ack.bind(),
+        retryNum: boltHelpers.extractRetryNumFromHTTPRequest(req),
+        retryReason: boltHelpers.extractRetryReasonFromHTTPRequest(req),
+      };
+
+      try {
+        logger.info("Processing Slack request", {
+          event,
+        });
+        await this.app?.processEvent(event);
+      } catch (error) {
+        logger.error("Failed to process Slack request", {
+          error,
+        })
+      }
+    } catch (error) {
+      logger.error("Failed to process Slack request", {
+        error,
+      })
+    }
+  };
+}

--- a/control-plane/src/modules/workflows/metadata.test.ts
+++ b/control-plane/src/modules/workflows/metadata.test.ts
@@ -1,5 +1,5 @@
 import { createOwner } from "../test/util";
-import { getWorkflowsByMetadata } from "./metadata";
+import { getRunsByMetadata } from "./metadata";
 import { createRun } from "./workflows";
 
 describe("getWorkflowsByMetadata", () => {
@@ -24,7 +24,7 @@ describe("getWorkflowsByMetadata", () => {
       },
     });
 
-    const result = await getWorkflowsByMetadata({
+    const result = await getRunsByMetadata({
       clusterId: owner.clusterId,
       key: "foo",
       value: "bar",

--- a/control-plane/src/modules/workflows/metadata.ts
+++ b/control-plane/src/modules/workflows/metadata.ts
@@ -1,7 +1,7 @@
 import { and, eq, desc } from "drizzle-orm";
 import { db, workflowMetadata, workflows } from "../data";
 
-export const getWorkflowsByMetadata = async ({
+export const getRunsByMetadata = async ({
   clusterId,
   key,
   value,

--- a/control-plane/src/modules/workflows/router.ts
+++ b/control-plane/src/modules/workflows/router.ts
@@ -3,7 +3,7 @@ import { JsonSchemaInput } from "inferable/bin/types";
 import { contract } from "../contract";
 import { getJobReferences, getJobsForWorkflow } from "../jobs/jobs";
 import * as events from "../observability/events";
-import { getWorkflowsByMetadata } from "./metadata";
+import { getRunsByMetadata } from "./metadata";
 import { getRunMessagesForDisplay } from "./workflow-messages";
 import {
   createRetry,
@@ -320,7 +320,7 @@ export const runsRouter = initServer().router(
           };
         }
 
-        const result = await getWorkflowsByMetadata({
+        const result = await getRunsByMetadata({
           clusterId,
           key,
           value,

--- a/control-plane/src/utilities/env.ts
+++ b/control-plane/src/utilities/env.ts
@@ -41,6 +41,9 @@ const envSchema = z
     ANTHROPIC_API_KEY: z.string().optional(),
     COHERE_API_KEY: z.string().optional(),
 
+    SLACK_BOT_TOKEN: z.string(),
+    SLACK_SIGNING_SECRET: z.string(),
+
     SQS_RUN_PROCESS_QUEUE_URL: z.string(),
     SQS_RUN_GENERATE_NAME_QUEUE_URL: z.string(),
     SQS_CUSTOMER_TELEMETRY_QUEUE_URL: z.string(),

--- a/control-plane/src/utilities/env.ts
+++ b/control-plane/src/utilities/env.ts
@@ -41,8 +41,9 @@ const envSchema = z
     ANTHROPIC_API_KEY: z.string().optional(),
     COHERE_API_KEY: z.string().optional(),
 
-    SLACK_BOT_TOKEN: z.string(),
-    SLACK_SIGNING_SECRET: z.string(),
+    SLACK_BOT_TOKEN: z.string().optional(),
+    SLACK_SIGNING_SECRET: z.string().optional(),
+    SLACK_CLUSTER_ID: z.string().optional(),
 
     SQS_RUN_PROCESS_QUEUE_URL: z.string(),
     SQS_RUN_GENERATE_NAME_QUEUE_URL: z.string(),


### PR DESCRIPTION
Support for triggering Runs via Slack and appending new messages from the thread.

In the absence of the `SLACK_*` environment variables the feature is not enabled.

TODO:
- Messages are not yet delivered back to Slack from the Run
- Slack app oAuth flow is not handled, currently the Bot secret is a static environment variable

<img width="1366" alt="image" src="https://github.com/user-attachments/assets/af7a3472-534e-47c2-a29a-2dd38504cf4a" />
