### PR TITLE
feat: Slack replies

### DIFF
--- a/control-plane/src/modules/auth/auth.ts
+++ b/control-plane/src/modules/auth/auth.ts
@@ -5,7 +5,7 @@ import { clusterExists, getClusterDetails } from "../cluster";
 import * as clusterAuth from "./cluster";
 import * as clerkAuth from "./clerk";
 import * as customAuth from "./custom";
-import { getRunCustomAuthToken, getWorkflow } from "../workflows/workflows";
+import { getRunCustomAuthToken, getRun } from "../workflows/workflows";
 import { logger } from "../observability/logger";
 import { env } from "../../utilities/env";
 
@@ -289,7 +289,7 @@ export const extractAuthState = async (
           await this.canAccess({
             cluster: { clusterId: opts.run.clusterId },
           });
-          const workflow = await getWorkflow({
+          const workflow = await getRun({
             clusterId: opts.run.clusterId,
             runId: opts.run.runId,
           });

--- a/control-plane/src/modules/slack/index.test.ts
+++ b/control-plane/src/modules/slack/index.test.ts
@@ -1,0 +1,90 @@
+import { webApi } from '@slack/bolt';
+import { authenticateUser, handleNewRunMessage } from './index';
+import { AuthenticationError } from '../../utilities/errors';
+
+describe('slack', () => {
+  const client =  {
+    chat: {
+      postMessage: jest.fn()
+    },
+    users: {
+      info: jest.fn()
+    }
+  } as unknown as webApi.WebClient
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('handleNewRunMessage', () => {
+    it('should not send message if metadata is missing', async () => {
+      const message = {
+        id: '123',
+        clusterId: 'cluster-1',
+        runId: 'run-1',
+        type: 'agent' as const,
+        data: {
+          message: 'test message'
+        }
+      };
+
+      await handleNewRunMessage({ message, client });
+
+      expect(client.chat.postMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("authenticateUser", () => {
+    it('should fail is user key is missing', async () => {
+      await expect(authenticateUser({
+        event: {} as any,
+        client
+      })).rejects.toThrow(Error);
+    });
+
+    it('should fail if user is not confirmed', async () => {
+      (client.users.info as jest.Mock).mockResolvedValueOnce({ user: { is_email_confirmed: false } });
+
+      await expect(authenticateUser({
+        event: { user: 'U123' } as any,
+        client
+      })).rejects.toThrow(AuthenticationError);
+    })
+
+    it('should fail if user email is missing', async () => {
+      (client.users.info as jest.Mock).mockResolvedValueOnce({ user: { is_email_confirmed: true } });
+      await expect(authenticateUser({
+        event: { user: 'U123', } as any,
+        client
+      })).rejects.toThrow(AuthenticationError);
+    })
+
+    it('should fail if user email is not in authorized list', async () => {
+      (client.users.info as jest.Mock).mockResolvedValueOnce({
+        user: {
+          is_email_confirmed: true,
+          profile: { email: 'xHw0o@example.com' }
+        }
+      });
+
+      await expect(authenticateUser({
+        event: { user: 'U123' } as any,
+        client
+      })).rejects.toThrow(AuthenticationError);
+    })
+
+    it('should succeed if user is confirmed and email is in authorized list', async () => {
+      (client.users.info as jest.Mock).mockResolvedValueOnce({
+        user: {
+          is_email_confirmed: true,
+          profile: { email: 'xHw0o@example.com' }
+        }
+      })
+      await expect(authenticateUser({
+        event: { user: 'U123' } as any,
+        client,
+        authorizedUsers: ['xHw0o@example.com']
+      })).resolves.toBeTruthy();
+    })
+  });
+});

--- a/control-plane/src/modules/slack/index.ts
+++ b/control-plane/src/modules/slack/index.ts
@@ -12,8 +12,8 @@ import { workflowMessages } from '../data';
 
 let app: App | undefined;
 
-const THREAD_META_KEY = "stripeThreadTs";
-const CHANNEL_META_KEY = "stripeChannel";
+const THREAD_META_KEY = "slackThreadTs";
+const CHANNEL_META_KEY = "slackChannel";
 
 type MessageEvent = {
   event: KnownEventFromType<'message'>,
@@ -21,7 +21,7 @@ type MessageEvent = {
   clusterId: string
 }
 
-export const handleNewRunMessage = async ({ message, metadata }: {
+export const handleNewRunMessage = async ({ message, metadata, client = app?.client }: {
   message: {
     id: string;
     clusterId: string;
@@ -30,6 +30,7 @@ export const handleNewRunMessage = async ({ message, metadata }: {
     data: InferSelectModel<typeof workflowMessages>["data"];
   },
   metadata?: Record<string, string>;
+  client?: webApi.WebClient
 }) => {
   if (message.type !== "agent") {
     return
@@ -40,7 +41,7 @@ export const handleNewRunMessage = async ({ message, metadata }: {
   }
 
   if ('message' in message.data && message.data.message) {
-    app?.client.chat.postMessage({
+    client?.chat.postMessage({
       thread_ts: metadata[THREAD_META_KEY],
       channel: metadata[CHANNEL_META_KEY],
       mrkdwn: true,
@@ -74,6 +75,18 @@ export const start = async (fastify: FastifyInstance) => {
     })
   });
 
+  // Event listener for mentions
+  app.event('app_mention', async ({ event, client }) => {
+    logger.info("Received mention event. Responding.", event);
+
+    client.chat.postMessage({
+      thread_ts: event.ts,
+      channel: event.channel,
+      mrkdwn: true,
+      text: 'Hey! Currently, I can only respond to direct messages.'
+    })
+  })
+
   // Event listener for direct messages
   app.event('message', async ({ event, client }) => {
     logger.info("Received message event. Responding.", event);
@@ -89,32 +102,24 @@ export const start = async (fastify: FastifyInstance) => {
     }
 
     try {
-      await authenticateUser(event, client);
+      await authenticateUser({
+        event,
+        client
+      });
 
       if (hasThread(event)) {
-        const [run] = await getRunsByMetadata({
-          clusterId: SLACK_CLUSTER_ID,
-          key: THREAD_META_KEY,
-          value: event.thread_ts,
-          limit: 1,
+        await handleExistingThread({
+          event,
+          client,
+          clusterId: SLACK_CLUSTER_ID
         });
-
-        if (run)  {
-          await handleExistingThread({
-            event,
-            client,
-            run,
-            clusterId: SLACK_CLUSTER_ID
-          });
-          return
-        }
+      } else {
+        await handleNewThread({
+          event,
+          client,
+          clusterId: SLACK_CLUSTER_ID
+        });
       }
-
-      await handleNewThread({
-        event,
-        client,
-        clusterId: SLACK_CLUSTER_ID
-      });
 
     } catch (error) {
 
@@ -122,7 +127,7 @@ export const start = async (fastify: FastifyInstance) => {
         client.chat.postMessage({
           thread_ts: event.ts,
           channel: event.channel,
-          text: "Sorry, I couldn't authenticate you. Please ensure you have an Inferable account with the same email as your Slack account."
+          text: `Sorry, I am having trouble authenticating you.\n\nPlease ensure your Inferable account has access to cluster <${env.APP_ORIGIN}/clusters/${SLACK_CLUSTER_ID}|${SLACK_CLUSTER_ID}>.`
         })
         return
       }
@@ -159,23 +164,30 @@ const handleNewThread = async ({
   clusterId
 }: MessageEvent) => {
 
+  let thread = event.ts;
+  // If this message is part of a thread, associate the run with the thread rather than the message
+  if (hasThread(event)) {
+    thread = event.thread_ts;
+  }
+
   if ('text' in event && event.text) {
     const run = await createRunWithMessage({
       clusterId,
       message: event.text,
       type: "human",
       metadata: {
-        [THREAD_META_KEY]: event.ts,
+        [THREAD_META_KEY]: thread,
         [CHANNEL_META_KEY]: event.channel
       },
     });
 
     client.chat.postMessage({
-      thread_ts: event.ts,
+      thread_ts: thread,
       channel: event.channel,
       mrkdwn: true,
       text: `On it. I will get back to you soon.\nRun ID: <${env.APP_ORIGIN}/clusters/${clusterId}/runs/${run.id}|${run.id}>`,
     });
+
     return;
   }
 
@@ -184,23 +196,56 @@ const handleNewThread = async ({
 
 const handleExistingThread = async ({
   event,
-  run,
-} : MessageEvent & { run: Run }) => {
+  client,
+  clusterId
+} : MessageEvent ) => {
   if ('text' in event && event.text) {
-    await addMessageAndResume({
-      id: ulid(),
-      clusterId: run.clusterId,
-      runId: run.id,
-      message: event.text,
-      type: "human",
-    })
+
+    if (!hasThread(event)) {
+      throw new Error("Event had no thread_ts");
+    }
+
+    const [run] = await getRunsByMetadata({
+      clusterId,
+      key: THREAD_META_KEY,
+      value: event.thread_ts,
+      limit: 1,
+    });
+
+    // Message is within a thread which already has a Run, continue
+    if (run) {
+      await addMessageAndResume({
+        id: ulid(),
+        clusterId: run.clusterId,
+        runId: run.id,
+        message: event.text,
+        type: "human",
+      })
+    } else {
+      // Message is in a thread, but does't have a Run, start a new one
+      // TODO: Inferable doesn't have context for the original message, we should include this
+      await handleNewThread({
+        event,
+        client,
+        clusterId
+      })
+    }
+
     return
   }
 
   throw new Error("Event had no text")
 }
 
-const authenticateUser = async (event: KnownEventFromType<'message'>, client: webApi.WebClient) => {
+export const authenticateUser = async ({
+  event,
+  client,
+  authorizedUsers = env.SLACK_AUTHORIZED_USER_EMAILS ?? []
+}: {
+    event: KnownEventFromType<'message'>,
+    client: webApi.WebClient
+    authorizedUsers?: string[]
+  }) => {
   if (hasUser(event)) {
     const user = await client.users.info({
       user: event.user,
@@ -210,12 +255,13 @@ const authenticateUser = async (event: KnownEventFromType<'message'>, client: we
     const confirmed = user.user?.is_email_confirmed
     const email = user.user?.profile?.email
 
-    if (!confirmed || !email) {
+    logger.info('Authenticated Slack user', { email, authorizedUsers })
+    // TODO: Verify user in Clerk, for now check env
+    if (!confirmed || !email || !authorizedUsers.includes(email)) {
       throw new AuthenticationError('Could not authenticate Slack user')
     }
 
-    // TODO: Verify user in Clerk
-    return
+    return true
   }
 
   throw new Error("Event had no user")

--- a/control-plane/src/modules/workflows/metadata.ts
+++ b/control-plane/src/modules/workflows/metadata.ts
@@ -43,7 +43,7 @@ export const getRunsByMetadata = async ({
     .limit(limit);
 };
 
-export const getWorkflowMetadata = async ({
+export const getRunMetadata = async ({
   clusterId,
   runId,
 }: {

--- a/control-plane/src/modules/workflows/router.ts
+++ b/control-plane/src/modules/workflows/router.ts
@@ -11,7 +11,7 @@ import {
   deleteRun,
   getClusterWorkflows,
   getRunConfigMetrics,
-  getWorkflow,
+  getRun,
   getWorkflowDetail,
   updateWorkflow,
 } from "./workflows";
@@ -370,7 +370,7 @@ export const runsRouter = initServer().router(
           runId,
           after: jobsAfter,
         }),
-        getWorkflow({
+        getRun({
           clusterId,
           runId,
         }),

--- a/control-plane/src/modules/workflows/workflows.ts
+++ b/control-plane/src/modules/workflows/workflows.ts
@@ -36,7 +36,7 @@ import {
 } from "./workflow-messages";
 import { env } from "../../utilities/env";
 import { injectTraceContext } from "../observability/tracer";
-import { getWorkflowMetadata } from "./metadata";
+import { getRunMetadata } from "./metadata";
 import { sqs } from "../sqs";
 import { ChatIdentifiers } from "../models/routing";
 import { customerTelemetry } from "../customer-telemetry";
@@ -244,7 +244,7 @@ export const updateWorkflow = async (workflow: Run): Promise<Run> => {
   return updated;
 };
 
-export const getWorkflow = async ({
+export const getRun = async ({
   clusterId,
   runId,
 }: {
@@ -358,7 +358,7 @@ export const getWorkflowDetail = async ({
       .from(workflows)
       .where(and(eq(workflows.cluster_id, clusterId), eq(workflows.id, runId))),
     lastAgentMessage({ clusterId, runId }),
-    getWorkflowMetadata({ clusterId, runId }),
+    getRunMetadata({ clusterId, runId }),
   ]);
 
   return {
@@ -553,7 +553,7 @@ export const assertRunReady = async (input: {
   runId: string;
   clusterId: string;
 }) => {
-  const run = await getWorkflow(input);
+  const run = await getRun(input);
   if (!run) {
     throw new NotFoundError("Run not found");
   }

--- a/control-plane/src/utilities/env.ts
+++ b/control-plane/src/utilities/env.ts
@@ -44,6 +44,12 @@ const envSchema = z
     SLACK_BOT_TOKEN: z.string().optional(),
     SLACK_SIGNING_SECRET: z.string().optional(),
     SLACK_CLUSTER_ID: z.string().optional(),
+    SLACK_AUTHORIZED_USER_EMAILS: z.string().optional().transform((value) => {
+      if (value) {
+        return value.split(",");
+      }
+      return [];
+    }),
 
     SQS_RUN_PROCESS_QUEUE_URL: z.string(),
     SQS_RUN_GENERATE_NAME_QUEUE_URL: z.string(),


### PR DESCRIPTION
- Allow Slack replies for direct messages
- Added some unit tests for Slack
- Adds `SLACK_AUTHORIZED_USER_EMAILS` until we support oAuth flow

Thread logic:
If the message is a new thread, A new run will be created.
If the message is in an existing thread without a run associated, a new run will be created and associated with the thread.
If the message is in an existing thread with a run associated, the existing run will be used.


<img width="393" alt="image" src="https://github.com/user-attachments/assets/d91a0c5a-2050-484f-84c4-8b9bcef0657d" />
<img width="386" alt="image" src="https://github.com/user-attachments/assets/8bc37d97-ee52-46bd-8388-78ad0998ef96" />
