### PR TITLE
feat: Remove `zod-to-json-schema` usage

### DIFF
--- a/control-plane/package-lock.json
+++ b/control-plane/package-lock.json
@@ -36,7 +36,6 @@
         "inferable": "^0.30.59",
         "jest": "^29.6.4",
         "js-tiktoken": "^1.0.12",
-        "json-schema-to-zod": "^2.1.0",
         "jsonpath": "^1.1.1",
         "jsonschema": "^1.4.1",
         "jsonwebtoken": "^9.0.2",
@@ -17539,15 +17538,6 @@
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
-      }
-    },
-    "node_modules/json-schema-to-zod": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-to-zod/-/json-schema-to-zod-2.4.1.tgz",
-      "integrity": "sha512-aMoez9TxgnfLAIZaWTPaQ+j7rOt1K9Ew/TBI85XcnhcFlo/47b1MDgpi4r07XndLSZWOX/KsJiRJvhdzSvo2Dw==",
-      "license": "ISC",
-      "bin": {
-        "json-schema-to-zod": "dist/cjs/cli.js"
       }
     },
     "node_modules/json-schema-traverse": {

--- a/control-plane/package.json
+++ b/control-plane/package.json
@@ -46,7 +46,6 @@
     "inferable": "^0.30.59",
     "jest": "^29.6.4",
     "js-tiktoken": "^1.0.12",
-    "json-schema-to-zod": "^2.1.0",
     "jsonpath": "^1.1.1",
     "jsonschema": "^1.4.1",
     "jsonwebtoken": "^9.0.2",

--- a/control-plane/src/modules/service-definitions.test.ts
+++ b/control-plane/src/modules/service-definitions.test.ts
@@ -1,8 +1,6 @@
-import { dereferenceSync, JSONSchema } from "dereference-json-schema";
 import { InvalidJobArgumentsError, InvalidServiceRegistrationError } from "../utilities/errors";
 import { packer } from "./packer";
 import {
-  deserializeFunctionSchema,
   embeddableServiceFunction,
   parseJobArgs,
   serviceFunctionEmbeddingId,
@@ -210,76 +208,6 @@ describe("parseJobArgs", () => {
           someNumber: 1,
         },
       }),
-    });
-  });
-});
-
-describe("deserializeFunctionSchema", () => {
-  const jsonSchema = {
-    $schema: "http://json-schema.org/draft-04/schema#",
-    title: "ExtractResult",
-    type: "object",
-    additionalProperties: false,
-    properties: {
-      posts: {
-        type: "array",
-        items: {
-          $ref: "#/definitions/Post",
-        },
-      },
-    },
-    definitions: {
-      Post: {
-        type: "object",
-        additionalProperties: false,
-        properties: {
-          id: {
-            type: "string",
-          },
-          title: {
-            type: "string",
-          },
-          points: {
-            type: "string",
-          },
-          comments_url: {
-            type: "string",
-          },
-        },
-      },
-    },
-  };
-
-  it("should convert a JSON schema to a Zod schema", () => {
-    const zodSchema = deserializeFunctionSchema(
-      dereferenceSync(jsonSchema as any),
-    );
-    const jsonSchema2 = zodToJsonSchema(zodSchema);
-    const dereferenced = dereferenceSync(jsonSchema2 as JSONSchema);
-    expect(dereferenced).toMatchObject({
-      properties: {
-        posts: {
-          type: "array",
-          items: {
-            type: "object",
-            additionalProperties: false,
-            properties: {
-              id: {
-                type: "string",
-              },
-              title: {
-                type: "string",
-              },
-              points: {
-                type: "string",
-              },
-              comments_url: {
-                type: "string",
-              },
-            },
-          },
-        },
-      },
     });
   });
 });

--- a/control-plane/src/modules/workflows/agent/agent.ai.test.ts
+++ b/control-plane/src/modules/workflows/agent/agent.ai.test.ts
@@ -190,6 +190,56 @@ describe("Agent", () => {
     });
   });
 
+  describe("result schema", () => {
+    jest.setTimeout(120000);
+
+    it("should result result schema", async () => {
+
+      const app = await createWorkflowAgent({
+        workflow: {
+          ...workflow,
+          resultSchema: {
+            type: "object",
+            properties: {
+              word: {
+                type: "string"
+              }
+            }
+          }
+        },
+        findRelevantTools: async () => tools,
+        getTool: async () => tools[0],
+        postStepSave: async () => {},
+      });
+
+      const messages = [
+        {
+          type: "human",
+          data: {
+            message: "Return the word 'hello'",
+          },
+        },
+      ];
+
+      const outputState = await app.invoke({
+        workflow,
+        messages,
+      });
+
+      expect(outputState.messages).toHaveLength(2);
+      expect(outputState.messages[0]).toHaveProperty("type", "human");
+      expect(outputState.messages[1]).toHaveProperty("type", "agent");
+      expect(outputState.messages[1].data.result).toHaveProperty(
+        "word",
+        "hello",
+      );
+
+      expect(outputState.result).toEqual({
+        word: "hello"
+      });
+    });
+  });
+
   describe("early exit", () => {
     jest.setTimeout(120000);
 

--- a/control-plane/src/modules/workflows/agent/nodes/model-output.test.ts
+++ b/control-plane/src/modules/workflows/agent/nodes/model-output.test.ts
@@ -1,0 +1,127 @@
+import { JsonSchema7ObjectType } from "zod-to-json-schema";
+import { WorkflowAgentState } from "../state";
+import { AgentTool } from "../tool";
+import { ulid } from "ulid";
+import { buildModelSchema } from "./model-output";
+
+describe("buildModelSchema", () => {
+  let state: WorkflowAgentState;
+  let relevantSchemas: AgentTool[];
+  let resultSchema: JsonSchema7ObjectType | undefined;
+
+  beforeEach(() => {
+  state = {
+    messages: [
+      {
+        id: ulid(),
+        clusterId: "test-cluster",
+        runId: "test-run",
+        data: {
+          message: "What are your capabilities?",
+        },
+        type: "human",
+      },
+    ],
+    waitingJobs: [],
+    allAvailableTools: [],
+    workflow: {
+      id: "test-run",
+      clusterId: "test-cluster",
+    },
+    additionalContext: "",
+    status: "running",
+  };
+    relevantSchemas = [
+      { name: "localTool1"},
+      { name: "localTool2"},
+      { name: "globalTool1"},
+      { name: "globalTool2"},
+    ] as AgentTool[],
+    resultSchema = undefined;
+  });
+
+  it("returns a schema with 'message' when resultSchema is not provided", () => {
+    const schema = buildModelSchema({ state, relevantSchemas, resultSchema });
+
+    expect(schema.type).toBe("object");
+    expect(schema.properties).toHaveProperty("message");
+    expect(schema.properties).not.toHaveProperty("result");
+  });
+
+  it("returns a schema with 'result' when resultSchema is provided", () => {
+    resultSchema = {
+      type: "object",
+      properties: {
+        foo: { type: "string" },
+      },
+      additionalProperties: false,
+    };
+
+    const schema = buildModelSchema({ state, relevantSchemas, resultSchema }) as any;
+
+    expect(schema.type).toBe("object");
+    expect(schema.properties).toHaveProperty("result");
+    expect(schema.properties).not.toHaveProperty("message");
+    expect(schema.properties?.result?.description).toContain("final result");
+  });
+
+  it("includes 'done' and 'issue' fields", () => {
+    const schema = buildModelSchema({ state, relevantSchemas, resultSchema }) as any;
+
+    expect(schema.properties).toHaveProperty("done");
+    expect(schema.properties).toHaveProperty("issue");
+    expect(schema.properties.done.type).toBe("boolean");
+    expect(schema.properties.issue.type).toBe("string");
+  });
+
+  it("builds the correct toolName enum from available tools", () => {
+    const schema = buildModelSchema({ state, relevantSchemas, resultSchema });
+    const invocations = schema.properties?.invocations as any;
+    const items = invocations.items as JsonSchema7ObjectType;
+    const toolName = items.properties?.toolName as any;
+
+    expect(toolName).toBeDefined();
+    expect(toolName?.enum).toContain("localTool1");
+    expect(toolName?.enum).toContain("localTool2");
+    expect(toolName?.enum).toContain("globalTool1");
+    expect(toolName?.enum).toContain("globalTool2");
+  });
+
+  it("includes 'invocations' with correct structure", () => {
+    const schema = buildModelSchema({ state, relevantSchemas, resultSchema });
+    const invocations = schema.properties?.invocations as any;
+
+    expect(invocations.type).toBe("array");
+    const items = invocations.items as any;
+
+    expect(items.type).toBe("object");
+    expect(items.additionalProperties).toBe(false);
+    expect(items.required).toEqual(["toolName", "input"]);
+
+    expect(items.properties?.input.type).toBe("object");
+    expect(items.properties?.input.additionalProperties).toBe(true);
+  });
+
+  it("does not include 'reasoning' by default", () => {
+    const schema = buildModelSchema({ state, relevantSchemas, resultSchema });
+    const invocations = schema.properties?.invocations as any;
+    const items = invocations.items as JsonSchema7ObjectType;
+
+    expect(items.properties).not.toHaveProperty("reasoning");
+  });
+
+  it("includes 'reasoning' when reasoningTraces is true", () => {
+    state.workflow.reasoningTraces = true;
+    const schema = buildModelSchema({ state, relevantSchemas, resultSchema });
+    const invocations = schema.properties?.invocations as any;
+    const items = invocations.items as any;
+
+    expect(items.properties).toHaveProperty("reasoning");
+    expect(items.properties?.reasoning?.type).toBe("string");
+  });
+
+  it("has additionalProperties set to false at top level", () => {
+    const schema = buildModelSchema({ state, relevantSchemas, resultSchema });
+    expect(schema.additionalProperties).toBe(false);
+  });
+});

--- a/control-plane/src/modules/workflows/agent/nodes/model-output.ts
+++ b/control-plane/src/modules/workflows/agent/nodes/model-output.ts
@@ -1,0 +1,101 @@
+
+import { JsonSchema7ObjectType } from "zod-to-json-schema";
+import { AgentTool } from "../tool";
+import { workflows } from "../../../data";
+import { InferSelectModel } from "drizzle-orm";
+import { WorkflowAgentState } from "../state";
+
+type ModelInvocationOutput = {
+  toolName: string;
+  input: unknown;
+
+}
+
+export type ModelOutput = {
+  invocations?: ModelInvocationOutput[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  result?: any;
+  message?: string;
+  done?: boolean;
+  issue?: string;
+}
+
+export const buildModelSchema = ({
+  state,
+  relevantSchemas,
+  resultSchema
+}: {
+  state: WorkflowAgentState;
+  relevantSchemas: AgentTool[];
+  resultSchema?: InferSelectModel<typeof workflows>["result_schema"];
+  }) => {
+
+  // Build the toolName enum
+  const toolNameEnum = [
+    ...relevantSchemas.map((tool) => tool.name),
+    ...state.allAvailableTools,
+  ];
+
+  const schema: JsonSchema7ObjectType = {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      done: {
+        type: "boolean",
+        description:
+          "Whether the workflow is done. All tasks have been completed or you can not progress further.",
+      },
+      issue: {
+        type: "string",
+        description:
+          "Describe any issues you have encountered in this step. Specifically related to the tools you are using.",
+      },
+    },
+  };
+
+  if (resultSchema) {
+    schema.properties.result = {
+      ...resultSchema,
+      description:
+        "Structured object describing the final result of the workflow, only provided once all tasks have been completed.",
+    };
+  } else {
+    schema.properties.message = {
+      type: "string",
+      description: "A message describing the current state or next steps.",
+    };
+  }
+
+  const invocationItemProperties: JsonSchema7ObjectType["properties"] = {
+    toolName: {
+      type: "string",
+      enum: toolNameEnum,
+    },
+    input: {
+      type: "object",
+      additionalProperties: true,
+      description: "Arbitrary input parameters for the tool call.",
+    },
+  };
+
+  if (state.workflow.reasoningTraces) {
+    invocationItemProperties.reasoning = {
+      type: "string",
+      description: "Reasoning trace for why this tool call is made.",
+    };
+  }
+
+  schema.properties.invocations = {
+    type: "array",
+    description:
+      "Any tool calls you need to make. If multiple are provided, they will be executed in parallel. DO NOT describe previous tool calls.",
+    items: {
+      type: "object",
+      additionalProperties: false,
+      properties: invocationItemProperties,
+      required: ["toolName", "input"],
+    },
+  };
+
+  return schema;
+};


### PR DESCRIPTION
Removes final `zod-to-json-schema` usage as it required running an `eval` at runtime.

Instead, build the model's output schema using JsonSchema directly.