### PR TITLE
feat: Support pointer references

### DIFF
--- a/sdk-go/inferable_test.go
+++ b/sdk-go/inferable_test.go
@@ -199,6 +199,7 @@ func TestGetSchema(t *testing.T) {
         "TestFunc": {
             "name": "TestFunc",
             "input": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
                 "type": "object",
                 "properties": {
                     "a": {"type": "integer"},
@@ -210,6 +211,7 @@ func TestGetSchema(t *testing.T) {
         "TestFunc2": {
             "name": "TestFunc2",
             "input": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
                 "type": "object",
                 "properties": {
                     "c": {

--- a/sdk-go/main_test.go
+++ b/sdk-go/main_test.go
@@ -62,12 +62,9 @@ func TestInferableFunctions(t *testing.T) {
 		t.Fatalf("Error registering reverse function: %v", err)
 	}
 
-	jsonDef, err := inferableInstance.toJSONDefinition()
 	if err != nil {
 		t.Fatalf("Error generating JSON definition: %v", err)
 	}
-	t.Logf("JSON Definition:\n%s\n", string(jsonDef))
-
 	t.Run("Echo Function", func(t *testing.T) {
 		testInput := EchoInput{Input: "Hello, Inferable!"}
 		result, err := inferableInstance.callFunc("string_operations", "echo", testInput)

--- a/sdk-go/service.go
+++ b/sdk-go/service.go
@@ -106,18 +106,18 @@ func (s *service) RegisterFunc(fn Function) (*FunctionReference, error) {
 	}
 	argType := fnType.In(0)
 
-  // Set the argument type to the referenced type
-  if argType.Kind() == reflect.Ptr {
-    argType = argType.Elem()
-  }
+	// Set the argument type to the referenced type
+	if argType.Kind() == reflect.Ptr {
+		argType = argType.Elem()
+	}
 
-  if argType.Kind() != reflect.Struct {
-    return nil, fmt.Errorf("function '%s' first argument must be a struct or a pointer to a struct", fn.Name)
-  }
+	if argType.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("function '%s' first argument must be a struct or a pointer to a struct", fn.Name)
+	}
 
-  // Get the schema for the input struct
-  reflector := jsonschema.Reflector{DoNotReference: true}
-  schema := reflector.Reflect(reflect.New(argType).Interface())
+	// Get the schema for the input struct
+	reflector := jsonschema.Reflector{DoNotReference: true, Anonymous: true}
+	schema := reflector.Reflect(reflect.New(argType).Interface())
 
 	if schema == nil {
 		return nil, fmt.Errorf("failed to get schema for function '%s'", fn.Name)

--- a/sdk-go/service.go
+++ b/sdk-go/service.go
@@ -105,13 +105,19 @@ func (s *service) RegisterFunc(fn Function) (*FunctionReference, error) {
 		return nil, fmt.Errorf("function '%s' must have exactly one argument", fn.Name)
 	}
 	argType := fnType.In(0)
-	if argType.Kind() != reflect.Struct {
-		return nil, fmt.Errorf("function '%s' first argument must be a struct", fn.Name)
-	}
 
-	// Get the schema for the input struct
-	reflector := jsonschema.Reflector{}
-	schema := reflector.Reflect(reflect.New(argType).Interface())
+  // Set the argument type to the referenced type
+  if argType.Kind() == reflect.Ptr {
+    argType = argType.Elem()
+  }
+
+  if argType.Kind() != reflect.Struct {
+    return nil, fmt.Errorf("function '%s' first argument must be a struct or a pointer to a struct", fn.Name)
+  }
+
+  // Get the schema for the input struct
+  reflector := jsonschema.Reflector{DoNotReference: true}
+  schema := reflector.Reflect(reflect.New(argType).Interface())
 
 	if schema == nil {
 		return nil, fmt.Errorf("failed to get schema for function '%s'", fn.Name)

--- a/sdk-go/service_test.go
+++ b/sdk-go/service_test.go
@@ -133,49 +133,6 @@ func TestRegistrationAndConfig(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestErrorneousRegistration(t *testing.T) {
-	machineSecret, _, _, apiEndpoint := util.GetTestVars()
-
-	machineID := "random-machine-id"
-
-	// Create a new Inferable instance
-	i, err := New(InferableOptions{
-		APIEndpoint: apiEndpoint,
-		APISecret:   machineSecret,
-		MachineID:   machineID,
-	})
-	require.NoError(t, err)
-
-	// Register a service
-	service, err := i.RegisterService("TestService1")
-	require.NoError(t, err)
-
-	type F struct {
-		G int `json:"g"`
-	}
-
-	// Register a test function
-	type TestInput struct {
-		A int `json:"a"`
-		B int `json:"b"`
-		C []struct {
-			D int    `json:"d"`
-			E string `json:"e"`
-			F []F    `json:"f"`
-		} `json:"c"`
-	}
-
-	testFunc := func(input TestInput) int { return input.A + input.B }
-
-	_, err = service.RegisterFunc(Function{
-		Func:        testFunc,
-		Name:        "TestFunc",
-		Description: "Test function",
-	})
-
-	require.ErrorContains(t, err, "schema for function 'TestFunc' contains a $ref to an external definition. this is currently not supported.")
-}
-
 func TestServiceStartAndReceiveMessage(t *testing.T) {
 	machineSecret, consumeSecret, clusterId, apiEndpoint := util.GetTestVars()
 


### PR DESCRIPTION
- Support struct **or** struct-pointer as first function arg
- Use `invopop/jsonschema`  `DoNotReference` option to denormalise `$ref` keys in json schemas