### PR TITLE
fix: Correct datetime tool format

### DIFF
--- a/control-plane/src/modules/workflows/agent/tools/date-time.ts
+++ b/control-plane/src/modules/workflows/agent/tools/date-time.ts
@@ -10,8 +10,13 @@ export const buildCurrentDateTimeTool = (): AgentTool =>
     schema: z.object({}),
     func: async () => {
       return JSON.stringify({
-        iso8601: new Date().toISOString(),
-        unix: new Date().getTime()
-      })
+        result: {
+
+          iso8601: new Date().toISOString(),
+          unix: new Date().getTime()
+        },
+        resultType: "resolution",
+        status: "success",
+      });
     },
   });


### PR DESCRIPTION
Correct result format for `currentDateTime` internal tool.