### PR TITLE
fix: Add job data anonymization before passing for context enrichment

### DIFF
--- a/control-plane/src/modules/jobs/jobs.test.ts
+++ b/control-plane/src/modules/jobs/jobs.test.ts
@@ -8,7 +8,6 @@ import {
   getJob,
   requestApproval,
   submitApproval,
-  anonymizeJob,
 } from "./jobs";
 import {
   acknowledgeJob,
@@ -419,7 +418,7 @@ describe("pollJobs", () => {
         .fill(0)
         .map(async () => {
           await new Promise((resolve) =>
-            setTimeout(resolve, Math.random() * 10),
+            setTimeout(resolve, Math.random() * 10)
           );
           return poll();
         }),

--- a/control-plane/src/modules/jobs/jobs.test.ts
+++ b/control-plane/src/modules/jobs/jobs.test.ts
@@ -2,7 +2,14 @@ import { ulid } from "ulid";
 import { packer } from "../packer";
 import { upsertServiceDefinition } from "../service-definitions";
 import { createOwner } from "../test/util";
-import { createJob, pollJobs, getJob, requestApproval, submitApproval } from "./jobs";
+import {
+  createJob,
+  pollJobs,
+  getJob,
+  requestApproval,
+  submitApproval,
+  anonymizeJob,
+} from "./jobs";
 import {
   acknowledgeJob,
   persistJobResult,
@@ -443,10 +450,8 @@ describe("submitApproval", () => {
       },
       owner,
     });
-
-  })
+  });
   it("should mark job as approved", async () => {
-
     const result = await createJob({
       targetFn: mockTargetFn,
       targetArgs: mockTargetArgs,
@@ -460,7 +465,7 @@ describe("submitApproval", () => {
     await requestApproval({
       clusterId: owner.clusterId,
       jobId: result.id,
-    })
+    });
 
     const retreivedJob1 = await getJob({
       jobId: result.id,
@@ -473,7 +478,7 @@ describe("submitApproval", () => {
       clusterId: owner.clusterId,
       call: retreivedJob1!,
       approved: true,
-    })
+    });
 
     const retreivedJob2 = await getJob({
       jobId: result.id,
@@ -489,7 +494,7 @@ describe("submitApproval", () => {
       clusterId: owner.clusterId,
       call: retreivedJob1!,
       approved: false,
-    })
+    });
 
     const retreivedJob3 = await getJob({
       jobId: result.id,
@@ -502,7 +507,6 @@ describe("submitApproval", () => {
   });
 
   it("should mark job as denied", async () => {
-
     const result = await createJob({
       targetFn: mockTargetFn,
       targetArgs: mockTargetArgs,
@@ -516,7 +520,7 @@ describe("submitApproval", () => {
     await requestApproval({
       clusterId: owner.clusterId,
       jobId: result.id,
-    })
+    });
 
     const retreivedJob1 = await getJob({
       jobId: result.id,
@@ -529,7 +533,7 @@ describe("submitApproval", () => {
       clusterId: owner.clusterId,
       call: retreivedJob1!,
       approved: false,
-    })
+    });
 
     const retreivedJob2 = await getJob({
       jobId: result.id,
@@ -545,7 +549,7 @@ describe("submitApproval", () => {
       clusterId: owner.clusterId,
       call: retreivedJob1!,
       approved: true,
-    })
+    });
 
     const retreivedJob3 = await getJob({
       jobId: result.id,
@@ -555,6 +559,5 @@ describe("submitApproval", () => {
     expect(retreivedJob3!.approved).toBe(false);
     expect(retreivedJob3!.status).toBe("success");
     expect(retreivedJob3!.resultType).toBe("rejection");
-
   });
 });

--- a/control-plane/src/modules/jobs/jobs.ts
+++ b/control-plane/src/modules/jobs/jobs.ts
@@ -1,4 +1,4 @@
-import { and, eq, gt, isNull, lte, sql } from "drizzle-orm";
+import { and, desc, eq, gt, isNull, lte, sql } from "drizzle-orm";
 import { env } from "../../utilities/env";
 import { JobPollTimeoutError, NotFoundError } from "../../utilities/errors";
 import { getBlobsForJobs } from "../blobs";
@@ -135,6 +135,38 @@ export const getJob = async ({
     ...job,
     blobs,
   };
+};
+
+export const getLatestJobsResultedByFunctionName = async ({
+  clusterId,
+  service,
+  functionName,
+  limit,
+  resultType,
+}: {
+  clusterId: string;
+  service: string;
+  functionName: string;
+  limit: number;
+  resultType: ResultType;
+}) => {
+  return data.db
+    .select({
+      result: data.jobs.result,
+      resultType: data.jobs.result_type,
+      targetArgs: data.jobs.target_args,
+    })
+    .from(data.jobs)
+    .where(
+      and(
+        eq(data.jobs.cluster_id, clusterId),
+        eq(data.jobs.target_fn, functionName),
+        eq(data.jobs.service, service),
+        eq(data.jobs.result_type, resultType),
+      ),
+    )
+    .orderBy(desc(data.jobs.created_at))
+    .limit(limit);
 };
 
 export const getJobsForWorkflow = async ({

--- a/control-plane/src/modules/tool-metadata.ts
+++ b/control-plane/src/modules/tool-metadata.ts
@@ -75,7 +75,6 @@ export async function getToolMetadata(
   const [result] = await db
     .select({
       additionalContext: toolMetadata.user_defined_context,
-      resultKeys: toolMetadata.result_keys,
     })
     .from(toolMetadata)
     .where(

--- a/control-plane/src/modules/workflows/agent/nodes/model-call.ts
+++ b/control-plane/src/modules/workflows/agent/nodes/model-call.ts
@@ -2,10 +2,7 @@ import { ReleventToolLookup } from "../agent";
 import { toAnthropicMessages } from "../../workflow-messages";
 import { logger } from "../../../observability/logger";
 import { WorkflowAgentState, WorkflowAgentStateMessage } from "../state";
-import {
-  addAttributes,
-  withSpan,
-} from "../../../observability/tracer";
+import { addAttributes, withSpan } from "../../../observability/tracer";
 import { AgentError } from "../../../../utilities/errors";
 import { ulid } from "ulid";
 
@@ -74,8 +71,7 @@ const _handleModelCall = async (
     "If there is nothing left to do, return 'done' and provide the final result.",
     "If you encounter invocation errors (e.g., incorrect tool name, missing input), retry based on the error message.",
     "When possible, return multiple invocations to trigger them in parallel.",
-    "Once all tasks have been completed, return the final result as a structured object.",
-    "Provide concise and clear responses. Use **bold** to highlight important words.",
+    "Provide concise and clear responses.",
     state.additionalContext,
     "<TOOLS_SCHEMAS>",
     schemaString,
@@ -262,7 +258,6 @@ const _handleModelCall = async (
       status: "running",
     };
   }
-
 
   return {
     messages: [

--- a/control-plane/src/modules/workflows/agent/nodes/model-output.ts
+++ b/control-plane/src/modules/workflows/agent/nodes/model-output.ts
@@ -1,4 +1,3 @@
-
 import { JsonSchema7ObjectType } from "zod-to-json-schema";
 import { AgentTool } from "../tool";
 import { workflows } from "../../../data";
@@ -8,8 +7,7 @@ import { WorkflowAgentState } from "../state";
 type ModelInvocationOutput = {
   toolName: string;
   input: unknown;
-
-}
+};
 
 export type ModelOutput = {
   invocations?: ModelInvocationOutput[];
@@ -18,18 +16,17 @@ export type ModelOutput = {
   message?: string;
   done?: boolean;
   issue?: string;
-}
+};
 
 export const buildModelSchema = ({
   state,
   relevantSchemas,
-  resultSchema
+  resultSchema,
 }: {
   state: WorkflowAgentState;
   relevantSchemas: AgentTool[];
   resultSchema?: InferSelectModel<typeof workflows>["result_schema"];
-  }) => {
-
+}) => {
   // Build the toolName enum
   const toolNameEnum = [
     ...relevantSchemas.map((tool) => tool.name),
@@ -48,7 +45,7 @@ export const buildModelSchema = ({
       issue: {
         type: "string",
         description:
-          "Describe any issues you have encountered in this step. Specifically related to the tools you are using.",
+          "Describe any issues you have encountered in this step. Specifically related to the tools you are using. If none, keep this field empty.",
       },
     },
   };

--- a/control-plane/src/modules/workflows/agent/run.test.ts
+++ b/control-plane/src/modules/workflows/agent/run.test.ts
@@ -51,10 +51,10 @@ describe("findRelevantTools", () => {
     });
 
     expect(tools.map((tool) => tool.name)).toContain(
-      "testService_someFunction",
+      "testService_someFunction"
     );
     expect(tools.map((tool) => tool.name)).not.toContain(
-      "testService_someOtherFunction",
+      "testService_someOtherFunction"
     );
   });
 });
@@ -164,11 +164,11 @@ describe("formatJobsContext", () => {
     expect(result).toContain('<jobs status="success">');
     expect(result).toContain("<input>");
     expect(result).toContain("<output>");
-    expect(result).toContain('"param1":"<STRING>"');
-    expect(result).toContain('"param2":"<NUMBER>"');
-    expect(result).toContain('"param3":"<BOOLEAN>"');
-    expect(result).toContain('"status":"<STRING>"');
-    expect(result).toContain('"count":"<NUMBER>"');
+    expect(result).toContain('"param1":"<string>"');
+    expect(result).toContain('"param2":"<number>"');
+    expect(result).toContain('"param3":"<boolean>"');
+    expect(result).toContain('"status":"<string>"');
+    expect(result).toContain('"count":"<number>"');
   });
 
   it("should handle null results", () => {
@@ -195,7 +195,7 @@ describe("formatJobsContext", () => {
           result: JSON.stringify([4, 5, 6]),
         },
       ],
-      "success",
+      "success"
     );
     expect(result).toContain(`<input>[\"<NUMBER>\"]</input>`);
     expect(result).toContain(`<output>[\"<NUMBER>\"]</output>`);

--- a/control-plane/src/modules/workflows/agent/run.test.ts
+++ b/control-plane/src/modules/workflows/agent/run.test.ts
@@ -184,7 +184,7 @@ describe("formatJobsContext", () => {
     expect(result).toContain('<previous_jobs status="failed">');
     expect(result).toContain("<input>");
     expect(result).toContain("<output>");
-    expect(result).toContain('"test":"<STRING>"');
+    expect(result).toContain('"test":"<string>"');
   });
 
   it("should anonymize arrays", () => {
@@ -197,7 +197,7 @@ describe("formatJobsContext", () => {
       ],
       "success"
     );
-    expect(result).toContain(`<input>[\"<NUMBER>\"]</input>`);
-    expect(result).toContain(`<output>[\"<NUMBER>\"]</output>`);
+    expect(result).toContain(`<input>[\"<number>\"]</input>`);
+    expect(result).toContain(`<output>[\"<number>\"]</output>`);
   });
 });

--- a/control-plane/src/modules/workflows/agent/run.test.ts
+++ b/control-plane/src/modules/workflows/agent/run.test.ts
@@ -161,7 +161,7 @@ describe("formatJobsContext", () => {
     const result = formatJobsContext(jobs, "success");
 
     // Verify structure and anonymization
-    expect(result).toContain('<jobs status="success">');
+    expect(result).toContain('<previous_jobs status="success">');
     expect(result).toContain("<input>");
     expect(result).toContain("<output>");
     expect(result).toContain('"param1":"<string>"');
@@ -181,7 +181,7 @@ describe("formatJobsContext", () => {
 
     const result = formatJobsContext(jobs, "failed");
 
-    expect(result).toContain('<jobs status="failed">');
+    expect(result).toContain('<previous_jobs status="failed">');
     expect(result).toContain("<input>");
     expect(result).toContain("<output>");
     expect(result).toContain('"test":"<STRING>"');

--- a/control-plane/src/modules/workflows/agent/run.ts
+++ b/control-plane/src/modules/workflows/agent/run.ts
@@ -264,13 +264,13 @@ export const processRun = async (
 
 function anonymize<T>(value: T): T {
   if (typeof value === "string") {
-    return "<STRING>" as T;
+    return "<string>" as T;
   } else if (value === null) {
-    return "<NULL>" as T;
+    return "<null>" as T;
   } else if (typeof value === "number") {
-    return "<NUMBER>" as T;
+    return "<number>" as T;
   } else if (typeof value === "boolean") {
-    return "<BOOLEAN>" as T;
+    return "<boolean>" as T;
   } else if (Array.isArray(value)) {
     return [anonymize(value[0])] as T;
   } else if (typeof value === "object") {

--- a/control-plane/src/modules/workflows/agent/run.ts
+++ b/control-plane/src/modules/workflows/agent/run.ts
@@ -32,6 +32,8 @@ import { CURRENT_DATE_TIME_TOOL_NAME } from "./tools/date-time";
 import { env } from "../../../utilities/env";
 import { events } from "../../observability/events";
 import { AgentTool } from "./tool";
+import { getLatestJobsResultedByFunctionName } from "../../jobs/jobs";
+import { truncate } from "lodash";
 
 /**
  * Run a workflow from the most recent saved state
@@ -259,6 +261,28 @@ export const processRun = async (
   }
 };
 
+const formatJobsContext = (
+  jobs: { targetArgs: string; result: string | null }[],
+  status: "success" | "failed",
+) => {
+  if (jobs.length === 0) return "";
+
+  const arbitraryLength = 500;
+
+  const jobEntries = jobs
+    .map(
+      (job) => `
+    <input>${truncate(job.targetArgs, { length: arbitraryLength })}</input>
+    <output>${truncate(job.result ?? "", { length: arbitraryLength })}</output>
+  `,
+    )
+    .join("\n");
+
+  return `<jobs status="${status}">
+    ${jobEntries}
+  </jobs>`;
+};
+
 async function findRelatedFunctionTools(workflow: Run, search: string) {
   const flags = await flagsmith?.getIdentityFlags(workflow.clusterId, {
     clusterId: workflow.clusterId,
@@ -284,13 +308,39 @@ async function findRelatedFunctionTools(workflow: Run, search: string) {
 
   const toolContexts = await Promise.all(
     relatedTools.map(async (toolDetails) => {
-      const metadata = await getToolMetadata(
-        workflow.clusterId,
-        toolDetails.serviceName,
-        toolDetails.functionName,
-      );
+      const [metadata, resolvedJobs, rejectedJobs] = await Promise.all([
+        getToolMetadata(
+          workflow.clusterId,
+          toolDetails.serviceName,
+          toolDetails.functionName,
+        ),
+        getLatestJobsResultedByFunctionName({
+          clusterId: workflow.clusterId,
+          service: toolDetails.serviceName,
+          functionName: toolDetails.functionName,
+          limit: 3,
+          resultType: "resolution",
+        }),
+        getLatestJobsResultedByFunctionName({
+          clusterId: workflow.clusterId,
+          service: toolDetails.serviceName,
+          functionName: toolDetails.functionName,
+          limit: 3,
+          resultType: "rejection",
+        }),
+      ]);
 
       const contextArr = [];
+
+      const successJobsContext = formatJobsContext(resolvedJobs, "success");
+      if (successJobsContext) {
+        contextArr.push(successJobsContext);
+      }
+
+      const failedJobsContext = formatJobsContext(rejectedJobs, "failed");
+      if (failedJobsContext) {
+        contextArr.push(failedJobsContext);
+      }
 
       if (metadata?.additionalContext) {
         contextArr.push(`<context>${metadata.additionalContext}</context>`);


### PR DESCRIPTION
Parse a JSON object as an anonymised string to prevent context leakage and save on the token spend.