### PR TITLE
chore: Catch previous job context errors

### DIFF
--- a/control-plane/src/modules/workflows/agent/run.ts
+++ b/control-plane/src/modules/workflows/agent/run.ts
@@ -290,22 +290,30 @@ export const formatJobsContext = (
 ) => {
   if (jobs.length === 0) return "";
 
-  const jobEntries = jobs
-    .map((job) =>
-      `
-    <input>${JSON.stringify(
-      anonymize(job.targetArgs ? JSON.parse(job.targetArgs) : job.targetArgs)
-    )}</input>
-    <output>${JSON.stringify(
-      anonymize(job.result ? JSON.parse(job.result) : job.result)
-    )}</output>
-  `.trim()
-    )
-    .join("\n");
+  try {
+    const jobEntries = jobs
+      .map((job) =>
+        `
+      <input>${JSON.stringify(
+        anonymize(job.targetArgs ? JSON.parse(job.targetArgs) : job.targetArgs)
+      )}</input>
+      <output>${JSON.stringify(
+        anonymize(job.result ? JSON.parse(job.result) : job.result)
+      )}</output>
+    `.trim()
+      )
+      .join("\n");
 
   return `<previous_jobs status="${status}">
     ${jobEntries}
   </previous_jobs>`;
+  } catch (error) {
+    logger.error("Failed to format jobs context", {
+      error,
+    })
+
+    return "";
+  }
 };
 
 async function findRelatedFunctionTools(workflow: Run, search: string) {


### PR DESCRIPTION
Previous job context formatting in #346 is causing some jobs to fail. 
Wrap it in a try catch.

https://www.hyperdx.io/search?q=%28%28level%3A%22error%22%29%29&tq=Dec+23+08%3A22%3A13+-+Dec+23+08%3A37%3A13&lid=cbee448c-cbf2-4abc-b2d7-ae56d3d8b5f6&sk=1734904952720000000&from=1734904333000&to=1734905233000