### PR TITLE
fix: Correct invocation result schema

### DIFF
--- a/app/components/chat/InvocationResult.tsx
+++ b/app/components/chat/InvocationResult.tsx
@@ -14,15 +14,10 @@ import { z } from "zod";
 import { ReadOnlyJSON } from "../read-only-json";
 import type { MessageContainerProps } from "./workflow-event";
 import ErrorDisplay from "../error-display";
-
-const invocationResultDataSchema = z.object({
-  id: z.string(),
-  result: z.unknown(),
-  createdAt: z.date(),
-});
+import { resultDataSchema } from "@/client/contract";
 
 export function InvocationResult(props: MessageContainerProps) {
-  const { success, data, error } = invocationResultDataSchema.safeParse(
+  const { success, data, error } = resultDataSchema.safeParse(
     props.data
   );
 


### PR DESCRIPTION

Invocation-result component was re-defining the message type's data schema and had an additional key `createdAt`.

<img width="837" alt="image" src="https://github.com/user-attachments/assets/bfe10374-ca24-4432-9fd4-c2a999b17369" />
