### PR TITLE
fix: Enable result grounding

### DIFF
--- a/control-plane/src/modules/workflows/router.ts
+++ b/control-plane/src/modules/workflows/router.ts
@@ -117,6 +117,7 @@ export const runsRouter = initServer().router(
         modelIdentifier: body.model,
         callSummarization: body.callSummarization,
         reasoningTraces: body.reasoningTraces,
+        enableResultGrounding: body.enableResultGrounding,
 
         input: body.input,
       };


### PR DESCRIPTION
Result grounding was not actually being read from the request body