### PR TITLE
feat: Add message history truncation

### DIFF
--- a/control-plane/src/modules/models/index.test.ts
+++ b/control-plane/src/modules/models/index.test.ts
@@ -10,6 +10,7 @@ const mockCreate = jest.fn(() => ({
 }));
 
 jest.mock("./routing", () => ({
+  ...jest.requireActual("./routing"),
   getRouting: jest.fn(() => ({
     buildClient: jest.fn(() => ({
       messages: {

--- a/control-plane/src/modules/models/index.ts
+++ b/control-plane/src/modules/models/index.ts
@@ -4,6 +4,7 @@ import Anthropic from "@anthropic-ai/sdk";
 import { ToolUseBlock } from "@anthropic-ai/sdk/resources";
 import {
   ChatIdentifiers,
+  CONTEXT_WINDOW,
   EmbeddingIdentifiers,
   getEmbeddingRouting,
   getRouting,
@@ -47,6 +48,7 @@ export type Model = {
     options: T,
   ) => Promise<StructuredCallOutput>;
   identifier: ChatIdentifiers | EmbeddingIdentifiers;
+  contextWindow?: number;
   embedQuery: (input: string) => Promise<number[]>;
 };
 
@@ -72,6 +74,7 @@ export const buildModel = ({
 
   return {
     identifier,
+    contextWindow: CONTEXT_WINDOW[identifier],
     embedQuery: async (input: string) => {
       if (!isEmbeddingIdentifier(identifier)) {
         throw new Error(`${identifier} is not an embedding model`);

--- a/control-plane/src/modules/models/routing.ts
+++ b/control-plane/src/modules/models/routing.ts
@@ -6,8 +6,8 @@ import { BedrockCohereEmbeddings } from "../embeddings/bedrock-cohere-embeddings
 import { CohereEmbeddings } from "@langchain/cohere";
 
 export const CONTEXT_WINDOW: Record<string, number> = {
-  "claude-3-5-sonnet": 1000,
-  "claude-3-haiku": 1000,
+  "claude-3-5-sonnet": 200_000,
+  "claude-3-haiku": 200_000,
 };
 
 const routingOptions = {

--- a/control-plane/src/modules/models/routing.ts
+++ b/control-plane/src/modules/models/routing.ts
@@ -5,6 +5,11 @@ import { logger } from "../observability/logger";
 import { BedrockCohereEmbeddings } from "../embeddings/bedrock-cohere-embeddings";
 import { CohereEmbeddings } from "@langchain/cohere";
 
+export const CONTEXT_WINDOW: Record<string, number> = {
+  "claude-3-5-sonnet": 1000,
+  "claude-3-haiku": 1000,
+};
+
 const routingOptions = {
   "claude-3-5-sonnet": [
     ...(env.BEDROCK_AVAILABLE

--- a/control-plane/src/modules/workflows/agent/nodes/system-prompt.ts
+++ b/control-plane/src/modules/workflows/agent/nodes/system-prompt.ts
@@ -1,8 +1,9 @@
 import { WorkflowAgentState } from "../state";
+import { AgentTool } from "../tool";
 
 export const getSystemPrompt = (
   state: WorkflowAgentState,
-  schemaString: string[],
+  tools: AgentTool[],
 ): string => {
   const basePrompt = [
     "You are a helpful assistant with access to a set of tools designed to assist in completing tasks.",
@@ -36,16 +37,19 @@ export const getSystemPrompt = (
     basePrompt.push(state.additionalContext);
   }
 
+
   // Add tool schemas
   basePrompt.push("<TOOLS_SCHEMAS>");
-  basePrompt.push(...schemaString);
+  basePrompt.push(...tools.map(tool => {
+    return `${tool.name} - ${tool.description} ${tool.schema}`;
+  }));
   basePrompt.push("</TOOLS_SCHEMAS>");
 
   // Add other available tools
   basePrompt.push("<OTHER_AVAILABLE_TOOLS>");
   basePrompt.push(
     ...state.allAvailableTools.filter(
-      (t) => !schemaString.find((s) => s.includes(t)),
+      (t) => !tools.find((s) => s.name === t),
     ),
   );
   basePrompt.push("</OTHER_AVAILABLE_TOOLS>");

--- a/control-plane/src/modules/workflows/agent/overflow.test.ts
+++ b/control-plane/src/modules/workflows/agent/overflow.test.ts
@@ -1,0 +1,219 @@
+import { AgentError } from '../../../utilities/errors';
+import { WorkflowAgentStateMessage } from './state';
+import { handleContextWindowOverflow } from './overflow';
+import { estimateTokenCount } from './utils';
+
+jest.mock('./utils', () => ({
+  estimateTokenCount: jest.fn(),
+}));
+
+describe('handleContextWindowOverflow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should throw if system prompt exceeds threshold', async () => {
+    const systemPrompt = 'System prompt';
+    const messages: WorkflowAgentStateMessage[] = [];
+    const modelContextWindow = 1000;
+
+    (estimateTokenCount as jest.Mock)
+      .mockResolvedValueOnce(701); // system prompt (0.7 * 1000)
+
+    await expect(
+      handleContextWindowOverflow({
+        systemPrompt,
+        messages,
+        modelContextWindow,
+      })
+    ).rejects.toThrow(new AgentError('System prompt can not exceed 700 tokens'));
+  });
+
+  it('should not modify messages if total tokens are under threshold', async () => {
+    const systemPrompt = 'System prompt';
+    const messages: WorkflowAgentStateMessage[] = [
+      { type: 'human', data: { message: 'Hello' } } as any,
+      { type: 'agent', data: { message: 'Hi' } } as any,
+    ];
+    const modelContextWindow = 1000;
+
+    (estimateTokenCount as jest.Mock)
+      .mockResolvedValueOnce(100) // system prompt
+      .mockResolvedValueOnce(200); // messages
+
+    const result = await handleContextWindowOverflow({
+      systemPrompt,
+      messages,
+      modelContextWindow,
+    });
+
+    expect(result).toEqual(messages);
+    expect(messages).toHaveLength(2);
+  });
+
+  it('should handle empty messages array', async () => {
+    const systemPrompt = 'System prompt';
+    const messages: WorkflowAgentStateMessage[] = [];
+    const modelContextWindow = 1000;
+
+    (estimateTokenCount as jest.Mock)
+      .mockResolvedValueOnce(200) // system prompt
+      .mockResolvedValueOnce(0); // empty messages
+
+    const result = await handleContextWindowOverflow({
+      systemPrompt,
+      messages,
+      modelContextWindow,
+    });
+
+    expect(result).toEqual(messages);
+    expect(messages).toHaveLength(0);
+  });
+
+  describe('truncate strategy', () => {
+    it('should remove messages until total tokens are under threshold', async () => {
+      const systemPrompt = 'System prompt';
+      const messages: WorkflowAgentStateMessage[] = Array(5).fill({
+        type: 'human',
+        data: { message: 'Message' },
+      });
+      const modelContextWindow = 600;
+
+      (estimateTokenCount as jest.Mock)
+        .mockResolvedValueOnce(200) // system prompt
+        .mockResolvedValueOnce(900) // initial messages
+        .mockResolvedValueOnce(700) // after first removal
+        .mockResolvedValueOnce(500) // after second removal
+        .mockResolvedValueOnce(300); // after third removal
+
+      const result = await handleContextWindowOverflow({
+        systemPrompt,
+        messages,
+        modelContextWindow,
+      });
+
+      expect(result).toHaveLength(2);
+    });
+
+    it('should throw if a single message exceeds the context window', async () => {
+      const systemPrompt = 'System prompt';
+      const messages: WorkflowAgentStateMessage[] = [
+        { type: 'human', data: { message: 'Message' } } as any,
+      ];
+      const modelContextWindow = 400;
+
+      (estimateTokenCount as jest.Mock)
+        .mockResolvedValueOnce(200) // system prompt
+        .mockResolvedValueOnce(400); // message
+
+      await expect(
+        handleContextWindowOverflow({
+          systemPrompt,
+          messages,
+          modelContextWindow,
+        })
+      ).rejects.toThrow(AgentError);
+    });
+
+
+    it('should remove tool invocation result when removing agent message', async () => {
+      const systemPrompt = 'System prompt';
+      const messages: WorkflowAgentStateMessage[] = [
+        { id: "123", type: 'agent', data: { message: 'Hi', invocations: [
+          {
+            id: "toolCallId1",
+          },
+          {
+            id: "toolCallId2",
+          },
+          {
+            id: "toolCallId3",
+          },
+        ]}} as any,
+        { id: "456", type: 'invocation-result', data: { id: "toolCallId1" } } as any,
+        { id: "456", type: 'invocation-result', data: { id: "toolCallId2" } } as any,
+        { id: "456", type: 'invocation-result', data: { id: "toolCallId3" } } as any,
+        { id: "789", type: 'human', data: { message: 'Hello' }} as any,
+      ];
+
+      // Only one message needs to be removed to satisfy context window
+      // 2 will be removed to ensure first message is human
+      const modelContextWindow = 1100;
+      (estimateTokenCount as jest.Mock)
+        .mockResolvedValueOnce(200) // system prompt
+        .mockResolvedValueOnce(1000) // initial messages
+        .mockResolvedValueOnce(800) // after first removal
+
+      const result = await handleContextWindowOverflow({
+        systemPrompt,
+        messages,
+        modelContextWindow,
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe('human');
+    });
+
+    it('should remove agent message when removing tool invocation result', async () => {
+      const systemPrompt = 'System prompt';
+      const messages: WorkflowAgentStateMessage[] = [
+        { id: "456", type: 'invocation-result', data: { id: "toolCallId1" } } as any,
+        { id: "123", type: 'agent', data: { message: 'Hi', invocations: [
+          {
+            id: "toolCallId1",
+          },
+        ]}} as any,
+        { id: "789", type: 'human', data: { message: 'Hello' }} as any,
+      ];
+
+      // Only one message needs to be removed to satisfy context window
+      // 2 will be removed to ensure first message is human
+      const modelContextWindow = 1100;
+      (estimateTokenCount as jest.Mock)
+        .mockResolvedValueOnce(200) // system prompt
+        .mockResolvedValueOnce(1000) // initial messages
+        .mockResolvedValueOnce(800) // after first removal
+        .mockResolvedValueOnce(600) // after second removal
+
+      const result = await handleContextWindowOverflow({
+        systemPrompt,
+        messages,
+        modelContextWindow,
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe('human');
+    })
+
+    it('should ensure first message is human', async () => {
+      const systemPrompt = 'System prompt';
+      const messages: WorkflowAgentStateMessage[] = [
+        { id: "789", type: 'human', data: { message: 'Hello' }} as any,
+        { id: "123", type: 'agent', data: { message: 'Hi', invocations: [
+          {
+            id: "toolCallId1",
+          },
+        ]}} as any,
+        { id: "789", type: 'human', data: { message: 'Hello' }} as any,
+      ];
+
+      // Only one message needs to be removed to satisfy context window
+      // 2 will be removed to ensure first message is human
+      const modelContextWindow = 1100;
+      (estimateTokenCount as jest.Mock)
+        .mockResolvedValueOnce(200) // system prompt
+        .mockResolvedValueOnce(1000) // initial messages
+        .mockResolvedValueOnce(800) // after first removal
+        .mockResolvedValueOnce(600) // after second removal
+
+      const result = await handleContextWindowOverflow({
+        systemPrompt,
+        messages,
+        modelContextWindow,
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe('human');
+    })
+  })
+});

--- a/control-plane/src/modules/workflows/agent/overflow.test.ts
+++ b/control-plane/src/modules/workflows/agent/overflow.test.ts
@@ -47,6 +47,8 @@ describe('handleContextWindowOverflow', () => {
       modelContextWindow,
     });
 
+    expect(estimateTokenCount).toHaveBeenCalledTimes(2);
+
     expect(result).toEqual(messages);
     expect(messages).toHaveLength(2);
   });
@@ -65,6 +67,8 @@ describe('handleContextWindowOverflow', () => {
       messages,
       modelContextWindow,
     });
+
+    expect(estimateTokenCount).toHaveBeenCalledTimes(2);
 
     expect(result).toEqual(messages);
     expect(messages).toHaveLength(0);
@@ -92,6 +96,8 @@ describe('handleContextWindowOverflow', () => {
         modelContextWindow,
       });
 
+      expect(estimateTokenCount).toHaveBeenCalledTimes(5);
+
       expect(result).toHaveLength(2);
     });
 
@@ -113,6 +119,8 @@ describe('handleContextWindowOverflow', () => {
           modelContextWindow,
         })
       ).rejects.toThrow(AgentError);
+
+      expect(estimateTokenCount).toHaveBeenCalledTimes(2)
     });
 
 
@@ -143,12 +151,17 @@ describe('handleContextWindowOverflow', () => {
         .mockResolvedValueOnce(200) // system prompt
         .mockResolvedValueOnce(1000) // initial messages
         .mockResolvedValueOnce(800) // after first removal
+        .mockResolvedValueOnce(600) // after second removal
+        .mockResolvedValueOnce(400) // after third removal
+        .mockResolvedValueOnce(200) // after fourth removal
 
       const result = await handleContextWindowOverflow({
         systemPrompt,
         messages,
         modelContextWindow,
       });
+
+      expect(estimateTokenCount).toHaveBeenCalledTimes(6);
 
       expect(result).toHaveLength(1);
       expect(result[0].type).toBe('human');
@@ -181,6 +194,8 @@ describe('handleContextWindowOverflow', () => {
         modelContextWindow,
       });
 
+      expect(estimateTokenCount).toHaveBeenCalledTimes(4);
+
       expect(result).toHaveLength(1);
       expect(result[0].type).toBe('human');
     })
@@ -211,6 +226,8 @@ describe('handleContextWindowOverflow', () => {
         messages,
         modelContextWindow,
       });
+
+      expect(estimateTokenCount).toHaveBeenCalledTimes(4);
 
       expect(result).toHaveLength(1);
       expect(result[0].type).toBe('human');

--- a/control-plane/src/modules/workflows/agent/overflow.ts
+++ b/control-plane/src/modules/workflows/agent/overflow.ts
@@ -1,0 +1,49 @@
+import { AgentError } from "../../../utilities/errors";
+import { logger } from "../../observability/logger";
+import { WorkflowAgentStateMessage } from "./state";
+import { estimateTokenCount } from "./utils";
+
+const TOTAL_CONTEXT_THRESHOLD = 0.95;
+const SYSTEM_PROMPT_THRESHOLD = 0.7;
+
+export const handleContextWindowOverflow = async ({
+  systemPrompt,
+  messages,
+  modelContextWindow,
+  render = JSON.stringify
+}: {
+  systemPrompt: string
+  messages: WorkflowAgentStateMessage[]
+  modelContextWindow: number
+  render? (message: WorkflowAgentStateMessage): unknown
+  //strategy?: "truncate"
+}) => {
+  const systemPromptTokenCount = await estimateTokenCount(systemPrompt);
+
+  if (systemPromptTokenCount > modelContextWindow * SYSTEM_PROMPT_THRESHOLD) {
+    throw new AgentError(`System prompt can not exceed ${modelContextWindow * SYSTEM_PROMPT_THRESHOLD} tokens`);
+  }
+
+  let messagesTokenCount = await estimateTokenCount(messages.map(render).join("\n"));
+  if (messagesTokenCount + systemPromptTokenCount < (modelContextWindow * TOTAL_CONTEXT_THRESHOLD)) {
+    return messages;
+  }
+
+  logger.info("Chat history exceeds context window, early messages will be dropped", {
+    systemPromptTokenCount,
+    messagesTokenCount,
+  })
+
+  do {
+    if (messages.length === 1) {
+      throw new AgentError("Single chat message exceeds context window");
+    }
+
+    messages.shift();
+
+    messagesTokenCount = await estimateTokenCount(messages.map(render).join("\n"));
+
+  } while (messagesTokenCount + systemPromptTokenCount > modelContextWindow * TOTAL_CONTEXT_THRESHOLD || messages[0].type !== 'human');
+
+  return messages;
+};

--- a/control-plane/src/modules/workflows/workflow-messages.ts
+++ b/control-plane/src/modules/workflows/workflow-messages.ts
@@ -244,7 +244,7 @@ export const getRunMessagesForDisplay = async ({
       displayableContext: workflowMessages.metadata,
     })
     .from(workflowMessages)
-    .orderBy(asc(workflowMessages.created_at))
+    .orderBy(desc(workflowMessages.created_at))
     .where(
       and(
         eq(workflowMessages.cluster_id, clusterId),


### PR DESCRIPTION
Adds `handleContextWindowOverflow` which truncates the chat history to ensure that it fits within the models context window. 

This will work through the message history removing the oldest message until it is within the context window and ensures that the history remains valid:
- Removes an `agent` message's subsequent invocation results
- Ensuring the conversation starts with a `human` message

This _only_ works on the messages that are fetched from the database (currently last 100). 
It should be a final guard to make sure what we are sending the model is not going to overflow.

Ideally we will also implement some history summarisation.