### PR TITLE
feat: Add a val.town integration (alpha)

### DIFF
--- a/app/app/clusters/[clusterId]/integrations/page.tsx
+++ b/app/app/clusters/[clusterId]/integrations/page.tsx
@@ -10,6 +10,8 @@ import Link from "next/link";
 import {
   ArrowRight,
   BarChartHorizontal,
+  FunctionSquare,
+  LucideIcon,
   Search,
   Trash2,
   Wrench,
@@ -20,32 +22,64 @@ import { auth } from "@clerk/nextjs";
 import ErrorDisplay from "@/components/error-display";
 import { revalidatePath } from "next/cache";
 
-const config = {
+type IntegrationConfig = {
+  [K in 'toolhouse' | 'langfuse' | 'tavily' | 'zapier' | 'valtown']: {
+    name: string;
+    description: string;
+    icon: LucideIcon;
+    stage: "alpha" | "beta" | "stable";
+  }
+};
+
+const config: IntegrationConfig = {
   toolhouse: {
     name: "Toolhouse",
     description:
       "Connect your toolhouse.ai tools directly to your Inferable Runs",
     icon: Wrench,
-    slug: "toolhouse",
+    stage: "beta",
   },
   langfuse: {
     name: "Langfuse",
     description: "Send LLM telemetry to Langfuse for monitoring and analytics",
     icon: BarChartHorizontal,
-    slug: "langfuse",
+    stage: "stable",
   },
   tavily: {
     name: "Tavily",
     description: "Use Tavily to search the web for information",
     icon: Search,
-    slug: "tavily",
+    stage: "stable",
   },
   zapier: {
     name: "Zapier",
     description: "Integrate your Inferable Runs with Zapier",
     icon: Zap,
-    slug: "zapier",
+    stage: "alpha",
   },
+  valtown: {
+    name: "Val.town",
+    description: "Register a service with a Val from Val.town",
+    icon: FunctionSquare,
+    stage: "alpha",
+  },
+};
+
+const stageDescriptions = {
+  "alpha": "In development, lacking docs",
+  "beta": "In testing, has docs",
+  "stable": "Stable, suitable for production use"
+} as const;
+
+const getStageStyles = (stage: "alpha" | "beta" | "stable") => {
+  switch (stage) {
+    case "alpha":
+      return "bg-red-100 text-red-700";
+    case "beta":
+      return "bg-yellow-100 text-yellow-700";
+    case "stable":
+      return "bg-green-100 text-green-700";
+  }
 };
 
 export default async function IntegrationsPage({
@@ -101,18 +135,27 @@ export default async function IntegrationsPage({
             .concat([["zapier", null]])
             .map(([key, integration]) => {
               const c = config[key as keyof typeof config];
-              const Icon = c?.icon;
+              if (!c) return null;
+              const Icon = c.icon;
 
               return (
                 <Card className="flex flex-col" key={key}>
                   <CardHeader>
                     <div className="flex items-center gap-2">
                       <Icon className="w-4 h-4" />
-                      <CardTitle>{c?.name}</CardTitle>
+                      <CardTitle>{c.name}</CardTitle>
+                      <div className="group relative">
+                        <span
+                          className={`text-xs px-2 py-0.5 rounded-full font-medium ${getStageStyles(c.stage)}`}
+                        >
+                          {c.stage}
+                        </span>
+                        <div className="invisible group-hover:visible absolute left-0 top-full mt-2 w-48 p-2 bg-gray-800 text-white text-xs rounded shadow-lg z-10">
+                          {stageDescriptions[c.stage]}
+                        </div>
+                      </div>
                     </div>
-                    <CardDescription>
-                      {c?.description ?? "Unknown"}
-                    </CardDescription>
+                    <CardDescription>{c.description}</CardDescription>
                   </CardHeader>
                   <CardContent className="flex-grow flex items-end">
                     <div className="w-full flex gap-2">

--- a/app/app/clusters/[clusterId]/integrations/valtown/page.tsx
+++ b/app/app/clusters/[clusterId]/integrations/valtown/page.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { client } from "@/client/client";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { createErrorToast } from "@/lib/utils";
+import { useAuth } from "@clerk/nextjs";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useCallback, useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import toast from "react-hot-toast";
+import { z } from "zod";
+import { ArrowLeft } from "lucide-react";
+import Link from "next/link";
+import { Loading } from "@/components/loading";
+
+const formSchema = z.object({
+  endpoint: z.string().url("Please enter a valid URL").min(1, "Endpoint URL is required"),
+});
+
+export default function ValtownIntegration({
+  params: { clusterId },
+}: {
+  params: { clusterId: string };
+}) {
+  const { getToken } = useAuth();
+  const [loading, setLoading] = useState(false);
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      endpoint: "",
+    },
+  });
+
+  const onSubmit = async (data: z.infer<typeof formSchema>) => {
+    const loadingToast = toast.loading("Saving configuration...");
+    const response = await client.upsertIntegrations({
+      headers: {
+        authorization: `Bearer ${await getToken()}`,
+      },
+      params: {
+        clusterId: clusterId,
+      },
+      body: {
+        valtown: {
+          endpoint: data.endpoint,
+        },
+      },
+    });
+
+    toast.dismiss(loadingToast);
+    if (response.status === 200) {
+      toast.success("Integration updated");
+      await fetchConfig();
+      return;
+    } else {
+      createErrorToast(response, "Failed to update integration");
+    }
+  };
+
+  const fetchConfig = useCallback(async () => {
+    setLoading(true);
+    const response = await client.getIntegrations({
+      headers: {
+        authorization: `Bearer ${await getToken()}`,
+      },
+      params: {
+        clusterId: clusterId,
+      },
+    });
+    setLoading(false);
+
+    if (response.status === 200) {
+      const result = z
+        .object({
+          endpoint: z.string(),
+        })
+        .safeParse(response.body?.valtown);
+
+      if (result.success) {
+        form.setValue("endpoint", result.data.endpoint);
+      }
+    }
+  }, [clusterId, getToken, form]);
+
+  useEffect(() => {
+    fetchConfig();
+  }, [fetchConfig]);
+
+  if (loading) {
+    return <Loading />;
+  }
+
+  return (
+    <div className="p-8 max-w-2xl">
+      <div className="mb-6">
+        <Link
+          href={`/clusters/${clusterId}/integrations`}
+          className="text-sm text-gray-500 hover:text-gray-700 flex items-center gap-2"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back to integrations
+        </Link>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-2 mb-2">
+            <span className="text-2xl">🏃</span>
+            <CardTitle>Configure Valtown</CardTitle>
+          </div>
+          <CardDescription>
+            Connect your Valtown Val endpoint to integrate with your function-as-a-service (FaaS) workflow.
+            The endpoint must conform to the FaaS specification for proper integration.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              <FormField
+                control={form.control}
+                name="endpoint"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Val Endpoint URL</FormLabel>
+                    <FormControl>
+                      <Input {...field} placeholder="https://myval.web.val.run" />
+                    </FormControl>
+                    <FormDescription>
+                      The URL endpoint of your Val that will be called for processing
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <Button type="submit">Save Configuration</Button>
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/client/contract.ts
+++ b/app/client/contract.ts
@@ -74,7 +74,7 @@ export const integrationSchema = z.object({
     })
     .optional()
     .nullable(),
-  valTown: z
+  valtown: z
     .object({
       endpoint: z.string().url(),
     })

--- a/control-plane/drizzle/0197_jazzy_solo.sql
+++ b/control-plane/drizzle/0197_jazzy_solo.sql
@@ -1,1 +1,2 @@
-ALTER TABLE "integrations" RENAME COLUMN "valTown" TO "valtown";
+ALTER TABLE "integrations" DROP COLUMN IF EXISTS "valTown";
+ALTER TABLE "integrations" ADD COLUMN "valtown" jsonb;

--- a/control-plane/drizzle/0197_jazzy_solo.sql
+++ b/control-plane/drizzle/0197_jazzy_solo.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "integrations" RENAME COLUMN "valTown" TO "valtown";

--- a/control-plane/drizzle/meta/0197_snapshot.json
+++ b/control-plane/drizzle/meta/0197_snapshot.json
@@ -1,0 +1,1658 @@
+{
+  "id": "78845134-955d-425e-8d0c-af295f29c3c4",
+  "prevId": "d3e75e3a-2bc7-411b-a33a-f6ccb9993bd1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.analytics_snapshots": {
+      "name": "analytics_snapshots",
+      "schema": "",
+      "columns": {
+        "data": {
+          "name": "data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "analytics_snapshots_pkey": {
+          "name": "analytics_snapshots_pkey",
+          "columns": [
+            "timestamp"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_secret_hash_index": {
+          "name": "api_keys_secret_hash_index",
+          "columns": [
+            {
+              "expression": "secret_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_cluster_id_clusters_id_fk": {
+          "name": "api_keys_cluster_id_clusters_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "api_keys_cluster_id_id_pk": {
+          "name": "api_keys_cluster_id_id_pk",
+          "columns": [
+            "cluster_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.blobs": {
+      "name": "blobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "encoding": {
+          "name": "encoding",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blobs_cluster_id_job_id_jobs_cluster_id_id_fk": {
+          "name": "blobs_cluster_id_job_id_jobs_cluster_id_id_fk",
+          "tableFrom": "blobs",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "cluster_id",
+            "job_id"
+          ],
+          "columnsTo": [
+            "cluster_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "blobs_cluster_id_workflow_id_workflows_cluster_id_id_fk": {
+          "name": "blobs_cluster_id_workflow_id_workflows_cluster_id_id_fk",
+          "tableFrom": "blobs",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "cluster_id",
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "cluster_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "blobs_cluster_id_id_pk": {
+          "name": "blobs_cluster_id_id_pk",
+          "columns": [
+            "cluster_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.clusters": {
+      "name": "clusters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "debug": {
+          "name": "debug",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enable_custom_auth": {
+          "name": "enable_custom_auth",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "handle_custom_auth_function": {
+          "name": "handle_custom_auth_function",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default_handleCustomAuth'"
+        },
+        "enable_run_configs": {
+          "name": "enable_run_configs",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enable_knowledgebase": {
+          "name": "enable_knowledgebase",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_context": {
+          "name": "additional_context",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clusters_id_org_index": {
+          "name": "clusters_id_org_index",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.embeddings": {
+      "name": "embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_1024": {
+          "name": "embedding_1024",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_data_hash": {
+          "name": "raw_data_hash",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "embedding1024Index": {
+          "name": "embedding1024Index",
+          "columns": [
+            {
+              "expression": "embedding_1024",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "embeddingsLookupIndex": {
+          "name": "embeddingsLookupIndex",
+          "columns": [
+            {
+              "expression": "cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "raw_data_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "embeddings_cluster_id_id_type_pk": {
+          "name": "embeddings_cluster_id_id_type_pk",
+          "columns": [
+            "cluster_id",
+            "id",
+            "type"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "machine_id": {
+          "name": "machine_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_fn": {
+          "name": "target_fn",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_type": {
+          "name": "result_type",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_usage_input": {
+          "name": "token_usage_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_usage_output": {
+          "name": "token_usage_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attention_level": {
+          "name": "attention_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "meta": {
+          "name": "meta",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        }
+      },
+      "indexes": {
+        "timeline_index": {
+          "name": "timeline_index",
+          "columns": [
+            {
+              "expression": "cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attention_level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.integrations": {
+      "name": "integrations",
+      "schema": "",
+      "columns": {
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "toolhouse": {
+          "name": "toolhouse",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "langfuse": {
+          "name": "langfuse",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tavily": {
+          "name": "tavily",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valtown": {
+          "name": "valtown",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "integrations_cluster_id_clusters_id_fk": {
+          "name": "integrations_cluster_id_clusters_id_fk",
+          "tableFrom": "integrations",
+          "tableTo": "clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "integrations_pkey": {
+          "name": "integrations_pkey",
+          "columns": [
+            "cluster_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_fn": {
+          "name": "target_fn",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_args": {
+          "name": "target_args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_key": {
+          "name": "cache_key",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_type": {
+          "name": "result_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executing_machine_id": {
+          "name": "executing_machine_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remaining_attempts": {
+          "name": "remaining_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resulted_at": {
+          "name": "resulted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_retrieved_at": {
+          "name": "last_retrieved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "function_execution_time_ms": {
+          "name": "function_execution_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeout_interval_seconds": {
+          "name": "timeout_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 300
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_context": {
+          "name": "auth_context",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_context": {
+          "name": "run_context",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_requested": {
+          "name": "approval_requested",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approved": {
+          "name": "approved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clusterServiceStatusIndex": {
+          "name": "clusterServiceStatusIndex",
+          "columns": [
+            {
+              "expression": "cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "service",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clusterServiceStatusFnIndex": {
+          "name": "clusterServiceStatusFnIndex",
+          "columns": [
+            {
+              "expression": "cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "service",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_fn",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "jobs_cluster_id_id": {
+          "name": "jobs_cluster_id_id",
+          "columns": [
+            "cluster_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "jobs_id_unique": {
+          "name": "jobs_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "public.machines": {
+      "name": "machines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_ping_at": {
+          "name": "last_ping_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sdk_version": {
+          "name": "sdk_version",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sdk_language": {
+          "name": "sdk_language",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "machines_id_cluster_id": {
+          "name": "machines_id_cluster_id",
+          "columns": [
+            "id",
+            "cluster_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.prompt_templates": {
+      "name": "prompt_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initial_prompt": {
+          "name": "initial_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attached_functions": {
+          "name": "attached_functions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "structured_output": {
+          "name": "structured_output",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_schema": {
+          "name": "input_schema",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_templates_cluster_id_clusters_id_fk": {
+          "name": "prompt_templates_cluster_id_clusters_id_fk",
+          "tableFrom": "prompt_templates",
+          "tableTo": "clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "prompt_templates_pkey": {
+          "name": "prompt_templates_pkey",
+          "columns": [
+            "cluster_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.services": {
+      "name": "services",
+      "schema": "",
+      "columns": {
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "queue_url": {
+          "name": "queue_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition": {
+          "name": "definition",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "services_cluster_id_clusters_id_fk": {
+          "name": "services_cluster_id_clusters_id_fk",
+          "tableFrom": "services",
+          "tableTo": "clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "services_cluster_id_service": {
+          "name": "services_cluster_id_service",
+          "columns": [
+            "cluster_id",
+            "service"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.tool_metadata": {
+      "name": "tool_metadata",
+      "schema": "",
+      "columns": {
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "function_name": {
+          "name": "function_name",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_defined_context": {
+          "name": "user_defined_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_keys": {
+          "name": "result_keys",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tool_metadata_cluster_id_clusters_id_fk": {
+          "name": "tool_metadata_cluster_id_clusters_id_fk",
+          "tableFrom": "tool_metadata",
+          "tableTo": "clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tool_metadata_pkey": {
+          "name": "tool_metadata_pkey",
+          "columns": [
+            "cluster_id",
+            "service",
+            "function_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.versioned_entities": {
+      "name": "versioned_entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "versioned_entities_pkey": {
+          "name": "versioned_entities_pkey",
+          "columns": [
+            "cluster_id",
+            "id",
+            "type",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.workflow_messages": {
+      "name": "workflow_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_messages_workflow_id_cluster_id_workflows_id_cluster_id_fk": {
+          "name": "workflow_messages_workflow_id_cluster_id_workflows_id_cluster_id_fk",
+          "tableFrom": "workflow_messages",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflow_id",
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id",
+            "cluster_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workflow_messages_cluster_id_workflow_id_id": {
+          "name": "workflow_messages_cluster_id_workflow_id_id",
+          "columns": [
+            "cluster_id",
+            "workflow_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.workflow_metadata": {
+      "name": "workflow_metadata",
+      "schema": "",
+      "columns": {
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workflowMetadataIndex": {
+          "name": "workflowMetadataIndex",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_metadata_workflow_id_cluster_id_workflows_id_cluster_id_fk": {
+          "name": "workflow_metadata_workflow_id_cluster_id_workflows_id_cluster_id_fk",
+          "tableFrom": "workflow_metadata",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflow_id",
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id",
+            "cluster_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workflow_metadata_cluster_id_workflow_id_key": {
+          "name": "workflow_metadata_cluster_id_workflow_id_key",
+          "columns": [
+            "cluster_id",
+            "workflow_id",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.workflows": {
+      "name": "workflows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_function": {
+          "name": "result_function",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_schema": {
+          "name": "result_schema",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_identifier": {
+          "name": "model_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debug": {
+          "name": "debug",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "attached_functions": {
+          "name": "attached_functions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "test": {
+          "name": "test",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "test_mocks": {
+          "name": "test_mocks",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::json"
+        },
+        "feedback_comment": {
+          "name": "feedback_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_score": {
+          "name": "feedback_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_version": {
+          "name": "config_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_traces": {
+          "name": "reasoning_traces",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "interactive": {
+          "name": "interactive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_summarization": {
+          "name": "enable_summarization",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enable_result_grounding": {
+          "name": "enable_result_grounding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "custom_auth_token": {
+          "name": "custom_auth_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_context": {
+          "name": "auth_context",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflows_cluster_id_clusters_id_fk": {
+          "name": "workflows_cluster_id_clusters_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workflows_cluster_id_id": {
+          "name": "workflows_cluster_id_id",
+          "columns": [
+            "cluster_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/control-plane/drizzle/meta/_journal.json
+++ b/control-plane/drizzle/meta/_journal.json
@@ -1373,6 +1373,13 @@
       "when": 1735114172602,
       "tag": "0196_giant_boom_boom",
       "breakpoints": true
+    },
+    {
+      "idx": 197,
+      "version": "7",
+      "when": 1735130489381,
+      "tag": "0197_jazzy_solo",
+      "breakpoints": true
     }
   ]
 }

--- a/control-plane/src/modules/contract.ts
+++ b/control-plane/src/modules/contract.ts
@@ -74,7 +74,7 @@ export const integrationSchema = z.object({
     })
     .optional()
     .nullable(),
-  valTown: z
+  valtown: z
     .object({
       endpoint: z.string().url(),
     })

--- a/control-plane/src/modules/data.ts
+++ b/control-plane/src/modules/data.ts
@@ -1,4 +1,5 @@
-import { relations, sql } from "drizzle-orm";
+import advisoryLock from "advisory-lock";
+import { sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/node-postgres";
 import {
   boolean,
@@ -18,7 +19,6 @@ import { Pool } from "pg";
 import { env } from "../utilities/env";
 import { logger } from "./observability/logger";
 import { MessageData } from "./workflows/workflow-messages";
-import advisoryLock from "advisory-lock";
 
 export const createMutex = advisoryLock(env.DATABASE_URL);
 
@@ -201,7 +201,7 @@ export const integrations = pgTable(
     tavily: json("tavily").$type<{
       apiKey: string;
     }>(),
-    valTown: json("valTown").$type<{
+    valtown: json("valtown").$type<{
       endpoint: string;
     }>(),
     created_at: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),

--- a/control-plane/src/modules/integrations/constants.ts
+++ b/control-plane/src/modules/integrations/constants.ts
@@ -1,13 +1,13 @@
 export const toolhouseIntegration = "toolhouse";
 export const langfuseIntegration = "langfuse";
 export const tavilyIntegration = "tavily";
-export const valTownIntegration = "valTown";
+export const valtownIntegration = "valtown";
 
 export const allowedIntegrations = [
   toolhouseIntegration,
   langfuseIntegration,
   tavilyIntegration,
-  valTownIntegration,
+  valtownIntegration,
 ] as const;
 
-export const externalServices = [toolhouseIntegration, tavilyIntegration, valTownIntegration];
+export const externalServices = [toolhouseIntegration, tavilyIntegration, valtownIntegration];

--- a/control-plane/src/modules/integrations/integrations.ts
+++ b/control-plane/src/modules/integrations/integrations.ts
@@ -2,15 +2,16 @@ import { eq, sql } from "drizzle-orm";
 import { z } from "zod";
 import { db, integrations } from "../data";
 import { integrationSchema } from "./schema";
-import { tavilyIntegration, valTownIntegration, toolhouseIntegration } from "./constants";
+import { tavilyIntegration, valtownIntegration, toolhouseIntegration } from "./constants";
 import { tavily } from "./tavily";
 import { toolhouse } from "./toolhouse";
-import { valTown } from "./val-town";
+import { valtown } from "./valtown";
+import { ToolProvider } from "./types";
 
-const toolProviders = {
+const toolProviders: Record<string, ToolProvider> = {
   [toolhouseIntegration]: toolhouse,
   [tavilyIntegration]: tavily,
-  [valTownIntegration]: valTown,
+  [valtownIntegration]: valtown,
 };
 
 export function getToolProvider(tool: string) {
@@ -31,7 +32,7 @@ export const getIntegrations = async ({
       toolhouse: integrations.toolhouse,
       langfuse: integrations.langfuse,
       tavily: integrations.tavily,
-      valTown: integrations.valTown,
+      valtown: integrations.valtown,
     })
     .from(integrations)
     .where(eq(integrations.cluster_id, clusterId))
@@ -41,7 +42,7 @@ export const getIntegrations = async ({
           toolhouse: null,
           langfuse: null,
           tavily: null,
-          valTown: null,
+          valtown: null,
         }
     );
 };
@@ -72,9 +73,9 @@ export const upsertIntegrations = async ({
   await Promise.all(
     Object.entries(config).map(([key, value]) => {
       if (value) {
-        return getToolProvider(key)?.onActivate?.(clusterId);
+        return getToolProvider(key)?.onActivate?.(clusterId, config);
       } else if (value === null) {
-        return getToolProvider(key)?.onDeactivate?.(clusterId);
+        return getToolProvider(key)?.onDeactivate?.(clusterId, config);
       }
     })
   );

--- a/control-plane/src/modules/integrations/schema.ts
+++ b/control-plane/src/modules/integrations/schema.ts
@@ -3,7 +3,7 @@ import {
   toolhouseIntegration,
   langfuseIntegration,
   tavilyIntegration,
-  valTownIntegration,
+  valtownIntegration,
 } from "./constants";
 
 export const integrationSchema = z.object({
@@ -28,7 +28,7 @@ export const integrationSchema = z.object({
     })
     .optional()
     .nullable(),
-  [valTownIntegration]: z
+  [valtownIntegration]: z
     .object({
       endpoint: z.string().url(),
     })

--- a/control-plane/src/modules/integrations/types.ts
+++ b/control-plane/src/modules/integrations/types.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+import { integrationSchema } from "./schema";
+import { getJob } from "../jobs/jobs";
+
+export type ToolProvider = {
+  name: string;
+  onActivate: (clusterId: string, integrations: z.infer<typeof integrationSchema>) => Promise<void>;
+  onDeactivate: (
+    clusterId: string,
+    integrations: z.infer<typeof integrationSchema>
+  ) => Promise<void>;
+  handleCall: (
+    call: NonNullable<Awaited<ReturnType<typeof getJob>>>,
+    integrations: z.infer<typeof integrationSchema>
+  ) => Promise<void>;
+};


### PR DESCRIPTION
Val.town integration allows the developer to use a val to register a val, and use that as a service. Vals are called by inferable via the integration pathway.

This requires more work:
- [ ] https://github.com/inferablehq/inferable/issues/382
- [ ] https://github.com/inferablehq/inferable/issues/383