### PR TITLE
fix: Allow message history with only template message

### DIFF
--- a/control-plane/src/modules/workflows/agent/overflow.ts
+++ b/control-plane/src/modules/workflows/agent/overflow.ts
@@ -49,9 +49,9 @@ export const handleContextWindowOverflow = async ({
   }
 
   // First message should always be human
-  while (messages.length && messages[0].type !== "human") {
+  while (messages.length && !["human", "template"].includes(messages[0].type)) {
     if (messages.length === 1) {
-      logger.error("Only message in mesasge history is not human", {
+      logger.error("Only message in mesasge history is not human or template", {
         messageId: messages[0].id
       });
       throw new AgentError("Run state is invalid");

--- a/control-plane/src/modules/workflows/agent/overflow.ts
+++ b/control-plane/src/modules/workflows/agent/overflow.ts
@@ -51,7 +51,7 @@ export const handleContextWindowOverflow = async ({
   // First message should always be human
   while (messages.length && !["human", "template"].includes(messages[0].type)) {
     if (messages.length === 1) {
-      logger.error("Only message in mesasge history is not human or template", {
+      logger.error("Only message in message history is not human or template", {
         messageId: messages[0].id
       });
       throw new AgentError("Run state is invalid");


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed message history validation to accept both 'human' and 'template' message types as the first message in the history
- Updated error logging message to accurately reflect the expanded validation criteria
- Prevents invalid truncation of template messages in the message history



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>overflow.ts</strong><dd><code>Allow template messages in message history validation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

control-plane/src/modules/workflows/agent/overflow.ts

<li>Modified message type validation to allow both 'human' and 'template' <br>types as first message<br> <li> Updated error message to reflect the new validation logic<br>


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/396/files#diff-36f1b16b5f183ac1da238e7a519d29a0635994a1e6ed1909a144fb5bcadbf48d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information