### PR TITLE
feat: Integrate background run ID for cluster operations

### DIFF
--- a/control-plane/src/modules/auth/custom.ts
+++ b/control-plane/src/modules/auth/custom.ts
@@ -5,6 +5,7 @@ import { getJobStatusSync } from "../jobs/jobs";
 import { getServiceDefinition } from "../service-definitions";
 import { createCache, hashFromSecret } from "../../utilities/cache";
 import { getClusterDetails } from "../management";
+import { getClusterBackgroundRun } from "../workflows/workflows";
 
 const customAuthContextCache = createCache<{
   service: string;
@@ -74,6 +75,7 @@ export const verify = async ({
       owner: {
         clusterId,
       },
+      runId: getClusterBackgroundRun(clusterId),
     });
 
     const result = await getJobStatusSync({

--- a/control-plane/src/modules/data.ts
+++ b/control-plane/src/modules/data.ts
@@ -78,7 +78,7 @@ export const jobs = pgTable(
     function_execution_time_ms: integer("function_execution_time_ms"),
     timeout_interval_seconds: integer("timeout_interval_seconds").notNull().default(300),
     service: varchar("service", { length: 1024 }).notNull(),
-    workflow_id: varchar("workflow_id", { length: 1024 }),
+    workflow_id: varchar("workflow_id", { length: 1024 }).notNull(),
     auth_context: json("auth_context"),
     run_context: json("run_context"),
     approval_requested: boolean("approval_requested").notNull().default(false),

--- a/control-plane/src/modules/jobs/create-job.ts
+++ b/control-plane/src/modules/jobs/create-job.ts
@@ -1,16 +1,9 @@
 import { and, desc, eq, gte } from "drizzle-orm";
 import { ulid } from "ulid";
-import {
-  InvalidJobArgumentsError,
-  NotFoundError,
-} from "../../utilities/errors";
+import { InvalidJobArgumentsError, NotFoundError } from "../../utilities/errors";
 import * as data from "../data";
 import * as events from "../observability/events";
-import {
-  FunctionConfig,
-  getServiceDefinition,
-  parseJobArgs,
-} from "../service-definitions";
+import { FunctionConfig, getServiceDefinition, parseJobArgs } from "../service-definitions";
 import { extractWithJsonPath } from "../util";
 import { env } from "../../utilities/env";
 import { injectTraceContext } from "../observability/tracer";
@@ -41,7 +34,7 @@ const extractCacheKeyFromJsonPath = (path: string, args: unknown) => {
     if (error instanceof NotFoundError) {
       throw new InvalidJobArgumentsError(
         `Failed to extract cache key from arguments: ${error.message}`,
-        "https://docs.inferable.ai/pages/functions#config-cache",
+        "https://docs.inferable.ai/pages/functions#config-cache"
       );
     }
     throw error;
@@ -53,7 +46,7 @@ export const createJob = async (params: {
   targetFn: string;
   targetArgs: string;
   owner: { clusterId: string };
-  runId?: string;
+  runId: string;
   authContext?: unknown;
   runContext?: unknown;
   schemaUnavailableRetryCount?: number;
@@ -68,19 +61,18 @@ export const createJob = async (params: {
   });
 
   const { config, schema } =
-    serviceDefinition?.functions?.find((f) => f.name === params.targetFn) ?? {};
+    serviceDefinition?.functions?.find(f => f.name === params.targetFn) ?? {};
 
   // sometimes the schema is not available immediately after the service is
   // registered, so we retry a few times
   if (!schema && (params.schemaUnavailableRetryCount ?? 0) < 3) {
     // wait for the service to be available
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await new Promise(resolve => setTimeout(resolve, 1000));
 
     // retry
     return createJob({
       ...params,
-      schemaUnavailableRetryCount:
-        (params.schemaUnavailableRetryCount ?? 0) + 1,
+      schemaUnavailableRetryCount: (params.schemaUnavailableRetryCount ?? 0) + 1,
     });
   }
 
@@ -91,8 +83,7 @@ export const createJob = async (params: {
 
   const jobConfig = {
     timeoutIntervalSeconds: config?.timeoutSeconds,
-    maxAttempts:
-      (config?.retryCountOnStall ?? DEFAULT_RETRY_COUNT_ON_STALL) + 1,
+    maxAttempts: (config?.retryCountOnStall ?? DEFAULT_RETRY_COUNT_ON_STALL) + 1,
     jobId: params.toolCallId ?? ulid(),
   };
 
@@ -181,11 +172,8 @@ const createJobStrategies = {
           eq(data.jobs.target_fn, targetFn),
           eq(data.jobs.status, "success"),
           eq(data.jobs.result_type, "resolution"),
-          gte(
-            data.jobs.resulted_at,
-            new Date(Date.now() - cacheTTLSeconds * 1000),
-          ),
-        ),
+          gte(data.jobs.resulted_at, new Date(Date.now() - cacheTTLSeconds * 1000))
+        )
       )
       .orderBy(desc(data.jobs.resulted_at))
       .limit(1);
@@ -282,7 +270,7 @@ const onAfterJobCreated = async ({
           ...injectTraceContext(),
         }),
       })
-      .catch((e) => {
+      .catch(e => {
         logger.error("Failed to send external call to SQS", { error: e });
       });
   }

--- a/control-plane/src/modules/jobs/create-job.ts
+++ b/control-plane/src/modules/jobs/create-job.ts
@@ -20,7 +20,7 @@ type CreateJobParams = {
   pool?: string;
   timeoutIntervalSeconds?: number;
   maxAttempts: number;
-  runId?: string;
+  runId: string;
   authContext?: unknown;
   runContext?: unknown;
 };

--- a/control-plane/src/modules/jobs/jobs.test.ts
+++ b/control-plane/src/modules/jobs/jobs.test.ts
@@ -2,19 +2,10 @@ import { ulid } from "ulid";
 import { packer } from "../packer";
 import { upsertServiceDefinition } from "../service-definitions";
 import { createOwner } from "../test/util";
-import {
-  createJob,
-  pollJobs,
-  getJob,
-  requestApproval,
-  submitApproval,
-} from "./jobs";
-import {
-  acknowledgeJob,
-  persistJobResult,
-  selfHealJobs,
-} from "./persist-result";
+import { createJob, pollJobs, getJob, requestApproval, submitApproval } from "./jobs";
+import { acknowledgeJob, persistJobResult, selfHealJobs } from "./persist-result";
 import * as redis from "../redis";
+import { getClusterBackgroundRun } from "../workflows/workflows";
 
 const mockTargetFn = "testTargetFn";
 const mockTargetArgs = packer.pack({ test: "test" });
@@ -51,6 +42,7 @@ describe("createJob", () => {
       targetArgs: mockTargetArgs,
       owner,
       service: "testService",
+      runId: getClusterBackgroundRun(owner.clusterId),
     });
 
     expect(result.id).toBeDefined();
@@ -93,6 +85,7 @@ describe("selfHealJobs", () => {
       targetArgs: mockTargetArgs,
       owner,
       service: "testService",
+      runId: getClusterBackgroundRun(owner.clusterId),
     });
 
     expect(createJobResult.id).toBeDefined();
@@ -108,7 +101,7 @@ describe("selfHealJobs", () => {
     expect(acknowledged).toBeDefined();
 
     // wait for the job to timeout
-    await new Promise((resolve) => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 2000));
 
     // run the self heal job
     const healedJobs = await selfHealJobs();
@@ -150,6 +143,7 @@ describe("selfHealJobs", () => {
       targetArgs: mockTargetArgs,
       owner,
       service: "testService",
+      runId: getClusterBackgroundRun(owner.clusterId),
     });
 
     expect(createJobResult.id).toBeDefined();
@@ -161,7 +155,7 @@ describe("selfHealJobs", () => {
     });
 
     // wait for the job to timeout
-    await new Promise((resolve) => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 2000));
 
     // run the self heal job
     const healedJobs = await selfHealJobs();
@@ -204,6 +198,7 @@ describe("selfHealJobs", () => {
       targetArgs: mockTargetArgs,
       owner,
       service: "testService",
+      runId: getClusterBackgroundRun(owner.clusterId),
     });
 
     // acknowledge the job, so that it moves to running state
@@ -216,7 +211,7 @@ describe("selfHealJobs", () => {
     expect(acknowledged).toBeDefined();
 
     // wait for the job to timeout
-    await new Promise((resolve) => setTimeout(resolve, 2000));
+    await new Promise(resolve => setTimeout(resolve, 2000));
 
     // run the self heal job
     const healedJobs = await selfHealJobs();
@@ -256,6 +251,7 @@ describe("selfHealJobs", () => {
       owner,
       service: "testService",
       toolCallId,
+      runId: getClusterBackgroundRun(owner.clusterId),
     });
 
     expect(createJobResult1.id).toBeDefined();
@@ -267,6 +263,7 @@ describe("selfHealJobs", () => {
       owner,
       service: "testService",
       toolCallId,
+      runId: getClusterBackgroundRun(owner.clusterId),
     });
 
     expect(createJobResult2.id).toBe(createJobResult1.id);
@@ -301,6 +298,7 @@ describe("selfHealJobs", () => {
       targetArgs: mockTargetArgs,
       owner,
       service: "testService",
+      runId: getClusterBackgroundRun(owner.clusterId),
     });
 
     await acknowledgeJob({
@@ -325,6 +323,7 @@ describe("selfHealJobs", () => {
       targetArgs: mockTargetArgs,
       owner,
       service: "testService",
+      runId: getClusterBackgroundRun(owner.clusterId),
     });
 
     expect(createJobResult2.id).toBe(createJobResult1.id);
@@ -367,6 +366,7 @@ describe("pollJobs", () => {
       targetArgs: mockTargetArgs,
       owner,
       service,
+      runId: getClusterBackgroundRun(owner.clusterId),
     });
 
     const result = await pollJobs({
@@ -403,6 +403,7 @@ describe("pollJobs", () => {
       targetArgs: mockTargetArgs,
       owner,
       service,
+      runId: getClusterBackgroundRun(owner.clusterId),
     });
 
     const poll = () =>
@@ -417,9 +418,7 @@ describe("pollJobs", () => {
       ...Array(50)
         .fill(0)
         .map(async () => {
-          await new Promise((resolve) =>
-            setTimeout(resolve, Math.random() * 10)
-          );
+          await new Promise(resolve => setTimeout(resolve, Math.random() * 10));
           return poll();
         }),
     ]);
@@ -456,6 +455,7 @@ describe("submitApproval", () => {
       targetArgs: mockTargetArgs,
       owner,
       service: "testService",
+      runId: getClusterBackgroundRun(owner.clusterId),
     });
 
     expect(result.id).toBeDefined();
@@ -511,6 +511,7 @@ describe("submitApproval", () => {
       targetArgs: mockTargetArgs,
       owner,
       service: "testService",
+      runId: getClusterBackgroundRun(owner.clusterId),
     });
 
     expect(result.id).toBeDefined();

--- a/control-plane/src/modules/jobs/persist-result.test.ts
+++ b/control-plane/src/modules/jobs/persist-result.test.ts
@@ -4,6 +4,7 @@ import { createOwner } from "../test/util";
 import { createJob, getJobStatusSync, persistJobResult } from "./jobs";
 import { acknowledgeJob, selfHealJobs } from "./persist-result";
 import * as redis from "../redis";
+import { getClusterBackgroundRun } from "../workflows/workflows";
 
 jest.mock("../service-definitions", () => ({
   ...jest.requireActual("../service-definitions"),
@@ -29,6 +30,7 @@ describe("persistJobResult", () => {
       targetArgs,
       owner,
       service: "testService",
+      runId: getClusterBackgroundRun(owner.clusterId),
     });
 
     // last ping will be now
@@ -90,6 +92,7 @@ describe("persistJobResult", () => {
       targetArgs,
       owner,
       service,
+      runId: getClusterBackgroundRun(owner.clusterId),
     });
 
     await upsertMachine({
@@ -110,17 +113,15 @@ describe("persistJobResult", () => {
     const machineStallTimeout = 1;
 
     // wait 1s for the machine to stall
-    await new Promise((resolve) =>
-      setTimeout(resolve, machineStallTimeout * 1000),
-    );
+    await new Promise(resolve => setTimeout(resolve, machineStallTimeout * 1000));
 
     // self heal jobs with machine stall timeout of 1s
     const healedJobs = await selfHealJobs({ machineStallTimeout });
 
     expect(
       healedJobs.stalledMachines.some(
-        (x) => x.id === "testMachineId" && x.clusterId === owner.clusterId,
-      ),
+        x => x.id === "testMachineId" && x.clusterId === owner.clusterId
+      )
     ).toBe(true);
     expect(healedJobs.stalledRecovered).toContain(createJobResult.id);
   });
@@ -136,6 +137,7 @@ describe("persistJobResult", () => {
       targetArgs,
       owner,
       service,
+      runId: getClusterBackgroundRun(owner.clusterId),
     });
 
     // last ping will be now
@@ -187,6 +189,7 @@ describe("persistJobResult", () => {
       targetArgs,
       owner,
       service,
+      runId: getClusterBackgroundRun(owner.clusterId),
     });
 
     // last ping will be now

--- a/control-plane/src/modules/jobs/persist-result.ts
+++ b/control-plane/src/modules/jobs/persist-result.ts
@@ -120,22 +120,6 @@ export async function persistJobResult({
       });
     }
 
-    await upsertResultKeys({
-      clusterId: owner.clusterId,
-      service: updateResult[0].service,
-      functionName: updateResult[0].targetFn,
-      result,
-    }).catch(error => {
-      logger.warn("Failed to upsert result keys", {
-        error,
-        jobId,
-        clusterId: owner.clusterId,
-        service: updateResult[0].service,
-        targetFn: updateResult[0].targetFn,
-        result,
-      });
-    });
-
     events.write({
       type: "functionResulted",
       service: updateResult[0]?.service,

--- a/control-plane/src/modules/jobs/persist-result.ts
+++ b/control-plane/src/modules/jobs/persist-result.ts
@@ -2,7 +2,6 @@ import { and, eq, gt, isNotNull, isNull, lt, lte, or, sql } from "drizzle-orm";
 import * as data from "../data";
 import * as events from "../observability/events";
 import { logger } from "../observability/logger";
-import { upsertResultKeys } from "../tool-metadata";
 import { resumeRun } from "../workflows/workflows";
 
 type PersistResultParams = {

--- a/control-plane/src/modules/observability/events.test.ts
+++ b/control-plane/src/modules/observability/events.test.ts
@@ -1,5 +1,6 @@
 import * as jobs from "../jobs/jobs";
 import { createOwner } from "../test/util";
+import { getClusterBackgroundRun } from "../workflows/workflows";
 import * as events from "./events";
 
 jest.mock("../service-definitions", () => ({
@@ -64,10 +65,11 @@ describe("event-aggregation", () => {
           service,
           targetFn,
           targetArgs,
+          runId: getClusterBackgroundRun(clusterId),
         });
 
         // wait 100ms
-        await new Promise((resolve) => setTimeout(resolve, 100));
+        await new Promise(resolve => setTimeout(resolve, 100));
 
         await jobs.acknowledgeJob({
           jobId: job.id,
@@ -76,7 +78,7 @@ describe("event-aggregation", () => {
         });
 
         // wait 100ms
-        await new Promise((resolve) => setTimeout(resolve, 100));
+        await new Promise(resolve => setTimeout(resolve, 100));
 
         await jobs.persistJobResult({
           jobId: job.id,
@@ -90,7 +92,7 @@ describe("event-aggregation", () => {
         });
 
         return job.id;
-      }),
+      })
     );
 
     return { jobIds };
@@ -113,7 +115,7 @@ describe("event-aggregation", () => {
             jobId,
           },
         })
-        .then((a) => a.reverse());
+        .then(a => a.reverse());
 
       expect(activity[0].type).toEqual("jobCreated");
       expect(activity[1].type).toEqual("jobAcknowledged");

--- a/control-plane/src/modules/tool-metadata.ts
+++ b/control-plane/src/modules/tool-metadata.ts
@@ -12,66 +12,14 @@ export async function upsertUserDefinedContext(metadata: {
     .insert(toolMetadata)
     .values(metadata)
     .onConflictDoUpdate({
-      target: [
-        toolMetadata.cluster_id,
-        toolMetadata.service,
-        toolMetadata.function_name,
-      ],
+      target: [toolMetadata.cluster_id, toolMetadata.service, toolMetadata.function_name],
       set: {
         user_defined_context: metadata.user_defined_context,
       },
     });
 }
 
-export async function upsertResultKeys(metadata: {
-  clusterId: string;
-  service: string;
-  functionName: string;
-  result: string;
-}): Promise<void> {
-  const [existingMetadata] = await db
-    .select({ result_keys: toolMetadata.result_keys })
-    .from(toolMetadata)
-    .where(
-      and(
-        eq(toolMetadata.cluster_id, metadata.clusterId),
-        eq(toolMetadata.service, metadata.service),
-        eq(toolMetadata.function_name, metadata.functionName),
-      ),
-    )
-    .limit(1);
-
-  const parsedResult = JSON.parse(metadata.result);
-  const mostExpressiveKeys = filterMostExpressiveKeys(
-    parsedResult,
-    existingMetadata?.result_keys,
-  );
-
-  await db
-    .insert(toolMetadata)
-    .values({
-      result_keys: mostExpressiveKeys,
-      cluster_id: metadata.clusterId,
-      service: metadata.service,
-      function_name: metadata.functionName,
-    })
-    .onConflictDoUpdate({
-      target: [
-        toolMetadata.cluster_id,
-        toolMetadata.service,
-        toolMetadata.function_name,
-      ],
-      set: {
-        result_keys: mostExpressiveKeys,
-      },
-    });
-}
-
-export async function getToolMetadata(
-  cluster_id: string,
-  service: string,
-  function_name: string,
-) {
+export async function getToolMetadata(cluster_id: string, service: string, function_name: string) {
   const [result] = await db
     .select({
       additionalContext: toolMetadata.user_defined_context,
@@ -81,8 +29,8 @@ export async function getToolMetadata(
       and(
         eq(toolMetadata.cluster_id, cluster_id),
         eq(toolMetadata.service, service),
-        eq(toolMetadata.function_name, function_name),
-      ),
+        eq(toolMetadata.function_name, function_name)
+      )
     )
     .limit(1);
 
@@ -92,7 +40,7 @@ export async function getToolMetadata(
 export async function deleteToolMetadata(
   cluster_id: string,
   service: string,
-  function_name: string,
+  function_name: string
 ) {
   await db
     .delete(toolMetadata)
@@ -100,7 +48,7 @@ export async function deleteToolMetadata(
       and(
         eq(toolMetadata.cluster_id, cluster_id),
         eq(toolMetadata.service, service),
-        eq(toolMetadata.function_name, function_name),
-      ),
+        eq(toolMetadata.function_name, function_name)
+      )
     );
 }

--- a/control-plane/src/modules/workflows/notify.ts
+++ b/control-plane/src/modules/workflows/notify.ts
@@ -3,22 +3,25 @@ import * as jobs from "../jobs/jobs";
 import { logger } from "../observability/logger";
 import { packer } from "../packer";
 import { getRunMetadata } from "./metadata";
-import { Run } from "./workflows";
+import { getClusterBackgroundRun, Run } from "./workflows";
 import { workflowMessages } from "../data";
 import * as slack from "../slack";
 
-export const notifyNewMessage = async ({ message, metadata }: {
+export const notifyNewMessage = async ({
+  message,
+  metadata,
+}: {
   message: {
     id: string;
     clusterId: string;
     runId: string;
     type: InferSelectModel<typeof workflowMessages>["type"];
     data: InferSelectModel<typeof workflowMessages>["data"];
-  },
+  };
   metadata?: Record<string, string>;
 }) => {
   await slack.handleNewRunMessage({ message, metadata });
-}
+};
 
 export const notifyStatusChange = async ({
   run,
@@ -54,6 +57,7 @@ export const notifyStatusChange = async ({
         owner: {
           clusterId: run.clusterId,
         },
+        runId: getClusterBackgroundRun(run.clusterId),
       });
       logger.info("Created job with run result", {
         jobId: id,

--- a/control-plane/src/modules/workflows/workflows.ts
+++ b/control-plane/src/modules/workflows/workflows.ts
@@ -410,6 +410,14 @@ export const resumeRun = async (input: Pick<Run, "id" | "clusterId">) => {
     return;
   }
 
+  if (input.id === getClusterBackgroundRun(input.clusterId)) {
+    logger.debug("Skipping background run resume", {
+      runId: input.id,
+      clusterId: input.clusterId,
+    });
+    return;
+  }
+
   const sqsResult = await sqs.sendMessage({
     QueueUrl: env.SQS_RUN_PROCESS_QUEUE_URL,
     MessageBody: JSON.stringify({

--- a/control-plane/src/modules/workflows/workflows.ts
+++ b/control-plane/src/modules/workflows/workflows.ts
@@ -524,6 +524,15 @@ export const createRunWithMessage = async ({
   return workflow;
 };
 
+/**
+ * A background run allows calls that are not associated with a specific run to have a home.
+ * @param clusterId - The cluster ID
+ * @returns A unique ID for the background run
+ */
+export const getClusterBackgroundRun = (clusterId: string) => {
+  return `${clusterId}BACKGROUND`;
+};
+
 export const assertRunReady = async (input: { runId: string; clusterId: string }) => {
   const run = await getRun(input);
   if (!run) {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Introduced background run ID functionality for cluster operations
- Made runId parameter mandatory in job creation to ensure proper tracking
- Integrated background run ID in various modules:
  * Custom auth jobs
  * Call router endpoints
  * Job creation workflow
- Added utility function getClusterBackgroundRun to generate consistent background run IDs
- Updated tests to include background run ID in job creation
- Code formatting improvements and cleanup across multiple files



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>custom.ts</strong><dd><code>Add background run ID to custom auth jobs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

control-plane/src/modules/auth/custom.ts

- Added integration with cluster background run ID for job creation



</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/400/files#diff-cecb27ac9fc1492896bbe25d07c3db65aa249d92751d07d17aa20948b401d86f">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>router.ts</strong><dd><code>Integrate background run ID in calls router</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

control-plane/src/modules/calls/router.ts

<li>Added background run ID to job creation in createCall endpoint<br> <li> Code formatting and arrow function syntax updates<br> <li> Fixed linting issues and formatting<br>


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/400/files#diff-915dfb57f7823f43f16027fa88f30498d966c0c7f5daa1d34338d2289c999444">+12/-11</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>create-job.ts</strong><dd><code>Make runId mandatory in job creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

control-plane/src/modules/jobs/create-job.ts

<li>Made runId parameter required in createJob function<br> <li> Code formatting improvements and cleanup<br>


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/400/files#diff-6e53c4b559a47d5d48b0656dec19810a4d9c004845a5883978c6078db230ec67">+11/-23</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>workflows.ts</strong><dd><code>Add cluster background run ID generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

control-plane/src/modules/workflows/workflows.ts

<li>Added new getClusterBackgroundRun function to generate background run <br>IDs<br> <li> Added documentation for background run functionality<br>


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/400/files#diff-17e8112ac05d30dbcbdf5b549c08800a1a3f5dc79df9500931b34e7ac8c0dc25">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information