### PR TITLE
fix: Remove redundant validation for initialPrompt or configId

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -657,3 +657,11 @@ jobs:
         ROLLBAR_ACCESS_TOKEN: ${{ secrets.CLOUD_ROLLBAR_ACCESS_TOKEN }}
         ROLLBAR_USERNAME: ${{ github.actor }}
         DEPLOY_ID: ${{ steps.rollbar_pre_deploy.outputs.deploy_id }}
+
+  final-step:
+    runs-on: ubuntu-latest
+    needs: ${{ toJson(jobs) }}
+    if: always()
+    steps:
+      - name: Final Step
+        run: echo "All jobs completed"

--- a/control-plane/src/modules/workflows/router.ts
+++ b/control-plane/src/modules/workflows/router.ts
@@ -73,15 +73,6 @@ export const runsRouter = initServer().router(
       await auth.canAccess({ cluster: { clusterId } });
       auth.canCreate({ run: true });
 
-      if (!body.initialPrompt && !body.configId) {
-        return {
-          status: 400,
-          body: {
-            message: "initialPrompt or configId is required to create a workflow",
-          },
-        };
-      }
-
       if (body.attachedFunctions && body.attachedFunctions.length == 0) {
         return {
           status: 400,


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Removed redundant validation check that required either `initialPrompt` or `configId` to be present when creating a workflow
- Simplified the request validation logic in the workflow creation endpoint
- Maintains existing authentication and access control checks



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>router.ts</strong><dd><code>Remove unnecessary workflow creation validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

control-plane/src/modules/workflows/router.ts

<li>Removed redundant validation check for <code>initialPrompt</code> or <code>configId</code> <br>fields<br> <li> Simplified request validation logic in the workflow creation endpoint<br>


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/404/files#diff-ec9592ce01e121f7ef9dfb72f9726dcb795c07245e6ad808a8621b96ae8667bc">+0/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information