### PR TITLE
chore: Remove redundant final-step from build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -657,11 +657,3 @@ jobs:
         ROLLBAR_ACCESS_TOKEN: ${{ secrets.CLOUD_ROLLBAR_ACCESS_TOKEN }}
         ROLLBAR_USERNAME: ${{ github.actor }}
         DEPLOY_ID: ${{ steps.rollbar_pre_deploy.outputs.deploy_id }}
-
-  final-step:
-    runs-on: ubuntu-latest
-    needs: ${{ toJson(jobs) }}
-    if: always()
-    steps:
-      - name: Final Step
-        run: echo "All jobs completed"


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Removed redundant `final-step` job from the build workflow that served no functional purpose
- The removed job was only echoing a completion message and depended on all other jobs
- Improves workflow clarity by removing unnecessary steps



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build.yml</strong><dd><code>Remove unnecessary final step from build workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/build.yml

<li>Removed redundant <code>final-step</code> job that only echoed "All jobs completed"<br> <br>


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/405/files#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721">+0/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information