### PR TITLE
feat: Cleanup conflicting Slack integrations

### DIFF
--- a/control-plane/src/modules/integrations/types.ts
+++ b/control-plane/src/modules/integrations/types.ts
@@ -4,14 +4,14 @@ import { getJob } from "../jobs/jobs";
 
 export type InstallableIntegration = {
   name: string;
-  onActivate: (clusterId: string, integrations: z.infer<typeof integrationSchema>) => Promise<void>;
+  onActivate: (clusterId: string, config: z.infer<typeof integrationSchema>) => Promise<void>;
   onDeactivate: (
     clusterId: string,
-    integrations: z.infer<typeof integrationSchema>,
-    existing: z.infer<typeof integrationSchema>
+    config: z.infer<typeof integrationSchema>,
+    prevConfig: z.infer<typeof integrationSchema>
   ) => Promise<void>;
   handleCall: (
     call: NonNullable<Awaited<ReturnType<typeof getJob>>>,
-    integrations: z.infer<typeof integrationSchema>
+    config: z.infer<typeof integrationSchema>
   ) => Promise<void>;
 };


### PR DESCRIPTION
### **User description**
Update Slack integration's `onActivate` handler to clean up any existing Slack integrations with the same teamId.


___

### **PR Type**
Enhancement


___

### **Description**
- Added functionality to clean up existing Slack integrations with the same teamId during activation to prevent duplicate integrations
- Improved function naming for better code readability and maintenance:
  - `getIntegrationForTeamId` → `integrationByTeam`
  - `getIntegrationForClusterId` → `integrationByCluster`
  - `uninstall` → `deleteNangoConnection`
- Added proper error handling and early returns in `onActivate` and `onDeactivate` handlers
- Implemented proper null checks for Slack connection IDs



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Enhance Slack integration activation and cleanup process</code>&nbsp; </dd></summary>
<hr>

control-plane/src/modules/integrations/slack/index.ts

<li>Added cleanup of existing Slack integrations during activation to <br>prevent duplicates<br> <li> Renamed functions for better clarity (e.g., <code>getIntegrationForTeamId</code> to <br><code>integrationByTeam</code>)<br> <li> Improved error handling in <code>onDeactivate</code> and <code>onActivate</code> handlers<br> <li> Split <code>uninstall</code> function into more specific <code>deleteNangoConnection</code><br>


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/409/files#diff-371db4e2ab9c97fb66d167e085aad6f537472811427c427967ef527f85dfa483">+27/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information