### PR TITLE
fix: Expand CORS bypass for /clusters/:id/calls endpoint

### DIFF
--- a/control-plane/src/index.ts
+++ b/control-plane/src/index.ts
@@ -35,7 +35,10 @@ app.register(initServer().plugin(router.router), parent => {
 
 const allowedOrigins = [env.APP_ORIGIN];
 
-const corsBypassRegex = new RegExp(/\/clusters\/.*\/runs/);
+const corsBypassRegexes = [
+  new RegExp(/\/clusters\/.*\/runs/),
+  new RegExp(/\/workflows\/.*\/calls/),
+];
 
 app.register(cors, {
   delegator: (req, callback) => {
@@ -46,7 +49,7 @@ app.register(cors, {
       return;
     }
 
-    if (corsBypassRegex.test(req.url ?? "")) {
+    if (corsBypassRegexes.some(regex => regex.test(req.url ?? ""))) {
       callback(null, {
         origin: true,
       });


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Enhanced CORS configuration by adding support for multiple bypass patterns
- Added new CORS bypass for '/workflows/:id/calls' endpoint while maintaining existing '/clusters/:id/runs' pattern
- Implemented array-based regex pattern matching using `some()` method for more flexible CORS bypass checks



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Expand CORS bypass patterns for workflow calls endpoint</code>&nbsp; &nbsp; </dd></summary>
<hr>

control-plane/src/index.ts

<li>Replaced single CORS bypass regex with an array of regex patterns<br> <li> Added new regex pattern for '/workflows/:id/calls' endpoint<br> <li> Updated CORS check to test URL against multiple regex patterns<br>


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/415/files#diff-975dcad7573ca181e177eadc1c377153dca688edca6288d8d689c7220f5c4947">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information