### PR TITLE
fix: Correct external service name casing

### DIFF
--- a/control-plane/src/modules/integrations/tavily.ts
+++ b/control-plane/src/modules/integrations/tavily.ts
@@ -6,6 +6,7 @@ import { packer } from "../packer";
 import { deleteServiceDefinition, upsertServiceDefinition } from "../service-definitions";
 import { integrationSchema } from "./schema";
 import { InstallableIntegration } from "./types";
+import { tavilyIntegration } from "./constants";
 
 const TavilySearchParamsSchema = z.object({
   query: z.string(),
@@ -67,7 +68,7 @@ export async function searchTavily({
 }
 
 const definition = {
-  name: "Tavily",
+  name: tavilyIntegration,
   functions: [
     {
       name: "search",
@@ -119,7 +120,7 @@ const syncTavilyService = async ({ clusterId, apiKey }: { clusterId: string; api
 
   await upsertServiceDefinition({
     type: "permanent",
-    service: "Tavily",
+    service: tavilyIntegration,
     definition,
     owner: { clusterId },
   });

--- a/control-plane/src/modules/integrations/toolhouse.ts
+++ b/control-plane/src/modules/integrations/toolhouse.ts
@@ -11,6 +11,7 @@ import { logger } from "../observability/logger";
 import { packer } from "../packer";
 import { upsertServiceDefinition } from "../service-definitions";
 import { InstallableIntegration } from "./types";
+import { toolhouseIntegration } from "./constants";
 
 const ToolHouseResultSchema = z.array(
   z.object({
@@ -159,9 +160,9 @@ const syncToolHouseService = async ({
   const tools = (await toolhouse.getTools()) as Anthropic.Messages.Tool[];
 
   await upsertServiceDefinition({
-    service: "ToolHouse",
+    service: toolhouseIntegration,
     definition: {
-      name: "ToolHouse",
+      name: toolhouseIntegration,
       functions: tools.map(tool => {
         return {
           name: toInferableName(tool.name),

--- a/control-plane/src/modules/integrations/valtown.ts
+++ b/control-plane/src/modules/integrations/valtown.ts
@@ -7,6 +7,7 @@ import { packer } from "../packer";
 import { deleteServiceDefinition, upsertServiceDefinition } from "../service-definitions";
 import { integrationSchema } from "./schema";
 import { InstallableIntegration } from "./types";
+import { valtownIntegration } from "./constants";
 
 // Schema for the /meta endpoint response
 const valtownMetaSchema = z.object({
@@ -93,9 +94,9 @@ const syncValTownService = async ({
 
   await upsertServiceDefinition({
     type: "permanent",
-    service: "valtown",
+    service: valtownIntegration,
     definition: {
-      name: "valtown",
+      name: valtownIntegration,
       description: meta.description,
       functions: meta.functions.map(fn => ({
         name: fn.name,


### PR DESCRIPTION
Fixes Toolhouse and Tavily integrations which are currently broken as their [constant names are lowercase](https://github.com/inferablehq/inferable/blob/main/control-plane/src/modules/integrations/constants.ts) where as their registration names are not.