### PR TITLE
chore: Move Slack approval text to top level

### DIFF
--- a/control-plane/src/modules/integrations/slack/index.ts
+++ b/control-plane/src/modules/integrations/slack/index.ts
@@ -166,14 +166,9 @@ export const handleApprovalRequest = async ({
   client?.chat.postMessage({
     thread_ts: metadata[THREAD_META_KEY],
     channel: metadata[CHANNEL_META_KEY],
+    mrkdwn: true,
+    text: `I need your approval to call \`${service}.${targetFn}\` on run <${env.APP_ORIGIN}/clusters/${clusterId}/runs/${runId}|${runId}>`,
     blocks: [
-      {
-        "type": "section",
-        "text": {
-          "type": "mrkdwn",
-          "text": `I need your approval to call \`${service}.${targetFn}\` on run <${env.APP_ORIGIN}/clusters/${clusterId}/runs/${runId}|${runId}>`
-        }
-      },
       {
         "type": "actions",
         "elements": [
@@ -620,19 +615,11 @@ const handleCallApprovalAction = async ({
     callId: action.value,
   });
 
-  const blockMessage = `${approved ? "✅" : "❌"} Call \`${action.value}\` was ${approved ? "approved" : "denied"}`;
+  const text = `${approved ? "✅" : "❌"} Call \`${action.value}\` was ${approved ? "approved" : "denied"}`;
 
   await client.chat.update({
     channel: channelId,
     ts: messageTs,
-    blocks: [
-      {
-        type: 'section',
-        text: {
-          type: 'mrkdwn',
-          text: blockMessage
-        },
-      },
-    ],
+    text,
   });
 };


### PR DESCRIPTION
### **User description**
Move Slack approval message text to top level to alleviate warning 

```
[WARN] web-api:WebClient:5 The top-level `text` argument is missing in the request payload for a chat.postMessage call - It's a best practice to always provide a `text` argument when posting a message. The `text` is used in places where the content cannot be rendered such as: system push notifications, assistive technology such as screen readers, etc.
```


___

### **PR Type**
Enhancement


___

### **Description**
- Moved Slack message text content from blocks to top-level `text` property to follow Slack API best practices and resolve warnings
- Added `mrkdwn: true` flag to ensure proper markdown formatting in messages
- Simplified message structure by removing unnecessary block wrappers while maintaining the same visual output
- Changes affect both initial approval request messages and approval response updates



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Refactor Slack message structure to use top-level text</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

control-plane/src/modules/integrations/slack/index.ts

<li>Moved Slack message text from blocks to top-level <code>text</code> property<br> <li> Added <code>mrkdwn: true</code> flag for markdown formatting support<br> <li> Simplified message update logic by using top-level text instead of <br>blocks


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/425/files#diff-371db4e2ab9c97fb66d167e085aad6f537472811427c427967ef527f85dfa483">+4/-17</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information