### PR TITLE
fix: Remove unused endpoint' field from valtownMetaSchema

### DIFF
--- a/control-plane/src/modules/integrations/valtown.test.ts
+++ b/control-plane/src/modules/integrations/valtown.test.ts
@@ -43,7 +43,6 @@ describe("Val.town Integration", () => {
   describe("fetchValTownMeta", () => {
     it("should fetch and parse metadata", async () => {
       const mockMeta = {
-        endpoint: "https://api.val.town",
         description: "Test description",
         functions: [
           {

--- a/control-plane/src/modules/integrations/valtown.ts
+++ b/control-plane/src/modules/integrations/valtown.ts
@@ -12,7 +12,6 @@ import { createSign } from "crypto";
 
 // Schema for the /meta endpoint response
 const valtownMetaSchema = z.object({
-  endpoint: z.string().url(),
   description: z.string(),
   functions: z.array(
     z.object({


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Simplified the `valtownMetaSchema` validation schema by removing the unused `endpoint` field that was previously defined as a URL string
- Schema now only validates the `description` and `functions` fields



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>valtown.ts</strong><dd><code>Remove unused endpoint field from schema validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

control-plane/src/modules/integrations/valtown.ts

<li>Removed unused <code>endpoint</code> field from <code>valtownMetaSchema</code> object schema <br>definition


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/435/files#diff-61cd5ecbcb89899b897e7946821c1240084107232ad33ecb16ab55d404786a94">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information