### PR TITLE
fix: Add deletion step before upserting service definition in ValTown integration

### DIFF
--- a/control-plane/src/modules/integrations/valtown.ts
+++ b/control-plane/src/modules/integrations/valtown.ts
@@ -146,6 +146,11 @@ const syncValTownService = async ({
 
   const meta = await fetchValTownMeta({ endpoint, privateKey });
 
+  await deleteServiceDefinition({
+    service: valtownIntegration,
+    owner: { clusterId },
+  });
+
   await upsertServiceDefinition({
     type: "permanent",
     service: valtownIntegration,


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Added a necessary deletion step before upserting service definition in ValTown integration
- This change ensures that the service definition is in a clean state before updating
- Prevents potential issues with stale or conflicting service definitions



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>valtown.ts</strong><dd><code>Add service definition deletion before upsert</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

control-plane/src/modules/integrations/valtown.ts

<li>Added a deletion step before upserting service definition in ValTown <br>integration<br> <li> Ensures clean state before service definition update


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/437/files#diff-61cd5ecbcb89899b897e7946821c1240084107232ad33ecb16ab55d404786a94">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information