### PR TITLE
chore: Remove redundant ServicesQuickstart component from page.tsx

### DIFF
--- a/app/app/clusters/[clusterId]/runs/page.tsx
+++ b/app/app/clusters/[clusterId]/runs/page.tsx
@@ -1,43 +1,11 @@
-import { client } from "@/client/client";
 import { PromptTextarea } from "@/components/chat/prompt-textarea";
-import ErrorDisplay from "@/components/error-display";
-import { ServicesQuickstart } from "@/components/services-quickstart";
 import { Card, CardContent } from "@/components/ui/card";
-import { auth } from "@clerk/nextjs";
 
 export default async function Page({
   params: { clusterId },
 }: {
   params: { clusterId: string };
 }) {
-  const { getToken } = auth();
-  const token = await getToken();
-
-  const response = await client.getCluster({
-    headers: {
-      authorization: `Bearer ${token}`,
-    },
-    params: {
-      clusterId: clusterId,
-    },
-  });
-
-  // TODO: limit this to one event.
-  const events = await client.listEvents({
-    headers: {
-      authorization: `Bearer ${token}`,
-    },
-    params: { clusterId },
-  });
-
-  if (response.status !== 200 || events.status !== 200) {
-    return <ErrorDisplay error={response.body} status={response.status} />;
-  }
-
-  if (events.body?.length === 0) {
-    return <ServicesQuickstart clusterId={clusterId} />;
-  }
-
   return (
     <div className="flex flex-col overflow-auto px-2 space-y-4">
       <Card className="w-full onboarding-prompt bg-white border border-gray-200 rounded-xl transition-all duration-200 hover:shadow-md mb-6">


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Simplified the runs page component by removing unnecessary code and dependencies
- Removed the `ServicesQuickstart` component and its related conditional rendering
- Eliminated unused API calls for cluster and events data
- Streamlined the component to focus on the prompt card functionality



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Simplify runs page by removing redundant quickstart component</code></dd></summary>
<hr>

app/app/clusters/[clusterId]/runs/page.tsx

<li>Removed unused imports (<code>client</code>, <code>ErrorDisplay</code>, <code>ServicesQuickstart</code>, <br><code>auth</code>)<br> <li> Removed cluster and events fetching logic<br> <li> Removed conditional rendering of <code>ServicesQuickstart</code> component<br> <li> Simplified component to only render the prompt card


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/444/files#diff-3f9d70337baee8168e4473954afc7fe185a551f4d177e5c17da8f6d89b5daf46">+0/-32</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information