### PR TITLE
chore: Refactor layout to use ClusterRunsLayout component

### DIFF
--- a/app/app/clusters/[clusterId]/runs/layout.tsx
+++ b/app/app/clusters/[clusterId]/runs/layout.tsx
@@ -1,6 +1,5 @@
 import { client } from "@/client/client";
-import { ClusterDetails } from "@/components/cluster-details";
-import { RunList } from "@/components/WorkflowList";
+import { ClusterRunsLayout } from "@/components/cluster-runs-layout";
 import { auth } from "@clerk/nextjs";
 
 export async function generateMetadata({
@@ -32,19 +31,5 @@ export default function Home({
   };
   children: React.ReactNode;
 }) {
-  return (
-    <div className="flex flex-col lg:flex-row gap-6 p-6">
-      <div className="w-full lg:w-[300px] flex-shrink-0">
-        <RunList clusterId={clusterId} />
-      </div>
-      <div className="w-full max-w-[1024px]">
-        {children}
-      </div>
-      <div className="w-full lg:w-[200px] flex-shrink-0">
-        <ClusterDetails clusterId={clusterId} />
-      </div>
-    </div>
-  );
+  return <ClusterRunsLayout clusterId={clusterId}>{children}</ClusterRunsLayout>;
 }
-
-

--- a/app/app/clusters/[clusterId]/runs/page.tsx
+++ b/app/app/clusters/[clusterId]/runs/page.tsx
@@ -1,13 +1,9 @@
 import { PromptTextarea } from "@/components/chat/prompt-textarea";
 import { Card, CardContent } from "@/components/ui/card";
 
-export default async function Page({
-  params: { clusterId },
-}: {
-  params: { clusterId: string };
-}) {
+export default async function Page({ params: { clusterId } }: { params: { clusterId: string } }) {
   return (
-    <div className="flex flex-col overflow-auto px-2 space-y-4">
+    <div className="flex flex-col overflow-auto space-y-4">
       <Card className="w-full onboarding-prompt bg-white border border-gray-200 rounded-xl transition-all duration-200 hover:shadow-md mb-6">
         <CardContent className="pt-6">
           <PromptTextarea clusterId={clusterId} />

--- a/app/components/cluster-runs-layout.tsx
+++ b/app/components/cluster-runs-layout.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { ClusterDetails } from "@/components/cluster-details";
+import { RunList } from "@/components/WorkflowList";
+import { useEffect, useState } from "react";
+import { Maximize2, Minimize2 } from "lucide-react";
+
+function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(false);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    const media = window.matchMedia(query);
+    setMatches(media.matches);
+
+    const listener = (e: MediaQueryListEvent) => setMatches(e.matches);
+    media.addEventListener("change", listener);
+    return () => media.removeEventListener("change", listener);
+  }, [query]);
+
+  return mounted ? matches : false;
+}
+
+interface ClusterRunsLayoutProps {
+  clusterId: string;
+  children: React.ReactNode;
+}
+
+export function ClusterRunsLayout({ clusterId, children }: ClusterRunsLayoutProps) {
+  const isSmallScreen = useMediaQuery("(max-width: 1024px)");
+  const [isMinimized, setIsMinimized] = useState(() => {
+    if (typeof window === "undefined") return false;
+    const key = `cluster-runs-layout-minimized-${isSmallScreen ? "small" : "large"}`;
+    const stored = localStorage.getItem(key);
+    return stored ? JSON.parse(stored) : false;
+  });
+
+  // Save to localStorage whenever isMinimized changes
+  useEffect(() => {
+    const key = `cluster-runs-layout-minimized-${isSmallScreen ? "small" : "large"}`;
+    localStorage.setItem(key, JSON.stringify(isMinimized));
+  }, [isMinimized, isSmallScreen]);
+
+  // On small screens, show maximized by default unless explicitly minimized
+  const isMaximized = isSmallScreen ? !isMinimized : isMinimized;
+
+  return (
+    <div className="flex flex-col lg:flex-row gap-6 p-6">
+      {!isMaximized && (
+        <div className="w-full lg:w-[300px] flex-shrink-0 transition-all duration-300">
+          <RunList clusterId={clusterId} />
+        </div>
+      )}
+      <div
+        className={`w-full ${!isMaximized ? "max-w-[1024px]" : ""} relative transition-all duration-300`}
+      >
+        <button
+          onClick={() => setIsMinimized(!isMinimized)}
+          className="absolute top-2 right-2 p-1.5 rounded-md bg-white hover:bg-gray-50 shadow-sm ring-1 ring-gray-200 transition-all z-10"
+          aria-label={isMaximized ? "Show sidebars" : "Hide sidebars"}
+        >
+          {isMaximized ? (
+            <Minimize2 className="w-3.5 h-3.5" />
+          ) : (
+            <Maximize2 className="w-3.5 h-3.5" />
+          )}
+        </button>
+        {children}
+      </div>
+      {!isMaximized && (
+        <div className="w-full lg:w-[200px] flex-shrink-0 transition-all duration-300">
+          <ClusterDetails clusterId={clusterId} />
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
### **User description**
Allows the run view to be maximized on small screens to preserve screen real-estate.

Fixes #374


___

### **PR Type**
Enhancement


___

### **Description**
- New ClusterRunsLayout component with responsive design

- Collapsible sidebars with minimize/maximize functionality

- Layout state persistence using localStorage

- Simplified and cleaner page structure


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>layout.tsx</strong><dd><code>Refactor layout to use centralized ClusterRunsLayout component</code></dd></summary>
<hr>

app/app/clusters/[clusterId]/runs/layout.tsx

<li>Removed direct usage of ClusterDetails and RunList components<br> <li> Simplified layout by using new ClusterRunsLayout component


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/450/files#diff-14d8fa3365c16c8fb062d32a52f3d8837f501fddd316df41889460f90f86ae70">+2/-17</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cluster-runs-layout.tsx</strong><dd><code>New responsive layout component with collapsible sidebars</code></dd></summary>
<hr>

app/components/cluster-runs-layout.tsx

<li>Created new component for managing cluster runs layout<br> <li> Added responsive layout with minimize/maximize functionality<br> <li> Implemented screen size detection and localStorage persistence<br> <li> Added toggle button for showing/hiding sidebars


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/450/files#diff-1e23455406763efffeeebe33cea429b7d378dc0e1053ad97ba49796d2a0429d3">+78/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Minor layout adjustments and code cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/app/clusters/[clusterId]/runs/page.tsx

<li>Simplified component props destructuring<br> <li> Removed unnecessary padding from container div


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/450/files#diff-3f9d70337baee8168e4473954afc7fe185a551f4d177e5c17da8f6d89b5daf46">+2/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information