### PR TITLE
chore: Refactor message types to use unified schema

### DIFF
--- a/control-plane/src/modules/data.ts
+++ b/control-plane/src/modules/data.ts
@@ -18,7 +18,6 @@ import {
 import { Pool } from "pg";
 import { env } from "../utilities/env";
 import { logger } from "./observability/logger";
-import { MessageData } from "./workflows/workflow-messages";
 
 export const createMutex = advisoryLock(env.DATABASE_URL);
 
@@ -323,7 +322,7 @@ export const workflowMessages = pgTable(
       withTimezone: true,
       precision: 6,
     }),
-    data: json("data").$type<MessageData>().notNull(),
+    data: json("data").$type<unknown>().notNull(),
     type: text("type", {
       enum: ["human", "invocation-result", "template", "agent", "agent-invalid", "supervisor"],
     }).notNull(),

--- a/control-plane/src/modules/router.ts
+++ b/control-plane/src/modules/router.ts
@@ -9,7 +9,7 @@ import * as data from "./data";
 import * as management from "./management";
 import * as events from "./observability/events";
 import {
-  assertGenericMessage,
+  assertMessageOfType,
   editHumanMessage,
   getRunMessagesForDisplay,
 } from "./workflows/workflow-messages";
@@ -300,7 +300,7 @@ export const router = initServer().router(contract, {
     const auth = request.request.getAuth();
     await auth.canManage({ run: { clusterId, runId } });
 
-    assertGenericMessage({
+    assertMessageOfType("human", {
       type: "human",
       data: {
         message,

--- a/control-plane/src/modules/workflows/agent/agent.ai.test.ts
+++ b/control-plane/src/modules/workflows/agent/agent.ai.test.ts
@@ -1,8 +1,8 @@
 import { createWorkflowAgent } from "./agent";
 import { z } from "zod";
-import { assertResultMessage } from "../workflow-messages";
 import { redisClient } from "../../redis";
 import { AgentTool } from "./tool";
+import { assertMessageOfType } from "../workflow-messages";
 
 if (process.env.CI) {
   jest.retryTimes(3);
@@ -89,10 +89,7 @@ describe("Agent", () => {
 
       expect(outputState.messages[0]).toHaveProperty("type", "human");
       expect(outputState.messages[1]).toHaveProperty("type", "agent");
-      expect(outputState.messages[2]).toHaveProperty(
-        "type",
-        "invocation-result",
-      );
+      expect(outputState.messages[2]).toHaveProperty("type", "invocation-result");
       expect(outputState.messages[3]).toHaveProperty("type", "agent");
     });
 
@@ -131,14 +128,8 @@ describe("Agent", () => {
       expect(outputState.messages).toHaveLength(5);
       expect(outputState.messages[0]).toHaveProperty("type", "human");
       expect(outputState.messages[1]).toHaveProperty("type", "agent");
-      expect(outputState.messages[2]).toHaveProperty(
-        "type",
-        "invocation-result",
-      );
-      expect(outputState.messages[3]).toHaveProperty(
-        "type",
-        "invocation-result",
-      );
+      expect(outputState.messages[2]).toHaveProperty("type", "invocation-result");
+      expect(outputState.messages[3]).toHaveProperty("type", "invocation-result");
       expect(outputState.messages[4]).toHaveProperty("type", "agent");
     });
 
@@ -176,21 +167,18 @@ describe("Agent", () => {
       expect(outputState.messages).toHaveLength(4);
       expect(outputState.messages[0]).toHaveProperty("type", "human");
       expect(outputState.messages[1]).toHaveProperty("type", "agent");
-      expect(outputState.messages[2]).toHaveProperty(
-        "type",
-        "invocation-result",
-      );
+      expect(outputState.messages[2]).toHaveProperty("type", "invocation-result");
       expect(outputState.messages[3]).toHaveProperty("type", "agent");
 
-      assertResultMessage(outputState.messages[2]);
-      const topLevelResult = outputState.messages[2].data.result;
-      Object.keys(topLevelResult).forEach((key) => {
+      const resultMessage = assertMessageOfType("invocation-result", outputState.messages[2]);
+      const topLevelResult = resultMessage.data.result;
+      Object.keys(topLevelResult).forEach(key => {
         expect(topLevelResult[key]).toEqual({
           result: "Failed to echo the word 'hello'",
           status: "success",
           resultType: "rejection",
         });
-      })
+      });
     });
   });
 
@@ -198,7 +186,6 @@ describe("Agent", () => {
     jest.setTimeout(120000);
 
     it("should result result schema", async () => {
-
       const app = await createWorkflowAgent({
         workflow: {
           ...workflow,
@@ -206,10 +193,10 @@ describe("Agent", () => {
             type: "object",
             properties: {
               word: {
-                type: "string"
-              }
-            }
-          }
+                type: "string",
+              },
+            },
+          },
         },
         findRelevantTools: async () => tools,
         getTool: async () => tools[0],
@@ -233,13 +220,10 @@ describe("Agent", () => {
       expect(outputState.messages).toHaveLength(2);
       expect(outputState.messages[0]).toHaveProperty("type", "human");
       expect(outputState.messages[1]).toHaveProperty("type", "agent");
-      expect(outputState.messages[1].data.result).toHaveProperty(
-        "word",
-        "hello",
-      );
+      expect(outputState.messages[1].data.result).toHaveProperty("word", "hello");
 
       expect(outputState.result).toEqual({
-        word: "hello"
+        word: "hello",
       });
     });
   });
@@ -304,15 +288,9 @@ describe("Agent", () => {
 
       expect(outputState.messages[0]).toHaveProperty("type", "human");
       expect(outputState.messages[1]).toHaveProperty("type", "agent");
-      expect(outputState.messages[2]).toHaveProperty(
-        "type",
-        "invocation-result",
-      );
+      expect(outputState.messages[2]).toHaveProperty("type", "invocation-result");
       expect(outputState.messages[3]).toHaveProperty("type", "agent");
-      expect(outputState.messages[4]).toHaveProperty(
-        "type",
-        "invocation-result",
-      );
+      expect(outputState.messages[4]).toHaveProperty("type", "invocation-result");
       expect(outputState.messages[5]).toHaveProperty("type", "agent");
     });
 
@@ -388,26 +366,18 @@ describe("Agent", () => {
 
       expect(outputState.messages[0]).toHaveProperty("type", "human");
       expect(outputState.messages[1]).toHaveProperty("type", "agent");
-      expect(outputState.messages[2]).toHaveProperty(
-        "type",
-        "invocation-result",
-      );
+      expect(outputState.messages[2]).toHaveProperty("type", "invocation-result");
       expect(outputState.messages[3]).toHaveProperty("type", "agent");
-      expect(outputState.messages[4]).toHaveProperty(
-        "type",
-        "invocation-result",
-      );
+      expect(outputState.messages[4]).toHaveProperty("type", "invocation-result");
       expect(outputState.messages[5]).toHaveProperty("type", "agent");
     });
-
 
     it("should respect mock responses", async () => {
       const tools = [
         new AgentTool({
           name: "searchHaystack",
           description: "Search haystack",
-          schema: z.object({
-          }).passthrough(),
+          schema: z.object({}).passthrough(),
           func: async (input: any) => {
             return toolCallback(input.input);
           },
@@ -421,15 +391,14 @@ describe("Agent", () => {
             type: "object",
             properties: {
               word: {
-                type: "string"
-              }
-            }
-          }
+                type: "string",
+              },
+            },
+          },
         },
         allAvailableTools: ["searchHaystack"],
         findRelevantTools: async () => tools,
-        getTool: async (input) =>
-          tools.find((tool) => tool.name === input.toolName)!,
+        getTool: async input => tools.find(tool => tool.name === input.toolName)!,
         postStepSave: async () => {},
         mockModelResponses: [
           JSON.stringify({
@@ -437,27 +406,28 @@ describe("Agent", () => {
             invocations: [
               {
                 toolName: "searchHaystack",
-                input: {}
-              }
-            ]
+                input: {},
+              },
+            ],
           }),
           JSON.stringify({
             done: true,
             result: {
-              word: "needle"
-            }
-          })
-        ]
+              word: "needle",
+            },
+          }),
+        ],
       });
 
-
-      toolCallback.mockResolvedValue(JSON.stringify({
-        result: JSON.stringify({
-          word: "needle"
-        }),
-        resultType: "resolution",
-        status: "success",
-      }));
+      toolCallback.mockResolvedValue(
+        JSON.stringify({
+          result: JSON.stringify({
+            word: "needle",
+          }),
+          resultType: "resolution",
+          status: "success",
+        })
+      );
 
       const outputState = await app.invoke({
         messages: [
@@ -475,14 +445,10 @@ describe("Agent", () => {
       expect(outputState.messages[1]).toHaveProperty("type", "agent");
       expect(outputState.messages[2]).toHaveProperty("type", "invocation-result");
       expect(outputState.messages[3]).toHaveProperty("type", "agent");
-      expect(outputState.messages[3].data).toHaveProperty(
-        "result",
-        {
-          word: "needle"
-        }
-      )
+      expect(outputState.messages[3].data).toHaveProperty("result", {
+        word: "needle",
+      });
       expect(toolCallback).toHaveBeenCalledTimes(1);
     });
   });
-
 });

--- a/control-plane/src/modules/workflows/agent/nodes/model-call.test.ts
+++ b/control-plane/src/modules/workflows/agent/nodes/model-call.test.ts
@@ -1,14 +1,11 @@
-import { ReleventToolLookup } from "../agent";
-import { handleModelCall } from "./model-call";
-import { z } from "zod";
-import { WorkflowAgentState } from "../state";
 import { ulid } from "ulid";
-import {
-  assertAgentMessage,
-  assertGenericMessage,
-} from "../../workflow-messages";
+import { z } from "zod";
 import { Model } from "../../../models";
+import { assertMessageOfType } from "../../workflow-messages";
+import { ReleventToolLookup } from "../agent";
+import { WorkflowAgentState } from "../state";
 import { AgentTool } from "../tool";
+import { handleModelCall } from "./model-call";
 
 describe("handleModelCall", () => {
   const workflow = {
@@ -71,7 +68,7 @@ describe("handleModelCall", () => {
       },
       structured: {
         done: true,
-        message: "nothing to do"
+        message: "nothing to do",
       },
     });
 
@@ -83,8 +80,8 @@ describe("handleModelCall", () => {
 
     expect(result.messages![0]).toHaveProperty("type", "agent");
 
-    assertAgentMessage(result.messages![0]);
-    expect(result.messages![0].data.invocations).not.toBeDefined();
+    const agentMessage = assertMessageOfType("agent", result.messages![0]);
+    expect(agentMessage.data.invocations).not.toBeDefined();
   });
 
   it("should ignore done if invocations are provided", async () => {
@@ -115,12 +112,12 @@ describe("handleModelCall", () => {
 
     expect(result.messages![0]).toHaveProperty("type", "agent");
 
-    assertAgentMessage(result.messages![0]);
+    const agentMessage = assertMessageOfType("agent", result.messages![0]);
 
     // Result should have been striped out
-    expect(result.messages![0].data.result).not.toBeDefined();
-    expect(result.messages![0].data.invocations).toHaveLength(1);
-    expect(result.messages![0].data.invocations).toContainEqual({
+    expect(agentMessage.data.result).not.toBeDefined();
+    expect(agentMessage.data.invocations).toHaveLength(1);
+    expect(agentMessage.data.invocations).toContainEqual({
       id: expect.any(String),
       toolName: "notify",
       input: { message: "A message" },
@@ -146,20 +143,20 @@ describe("handleModelCall", () => {
     expect(result.status).toBe("running");
 
     expect(result.messages![0]).toHaveProperty("type", "agent-invalid");
-    assertGenericMessage(result.messages![0]);
-    expect(result.messages![0].data).toHaveProperty(
+    const invalidMessage = assertMessageOfType("agent-invalid", result.messages![0]);
+    expect(invalidMessage.data).toHaveProperty(
       "details",
       expect.objectContaining({
         message: "nothing to do",
-      }),
+      })
     );
 
     expect(result.messages![1]).toHaveProperty("type", "supervisor");
-    assertGenericMessage(result.messages![1]);
+    const supervisorMessage = assertMessageOfType("supervisor", result.messages![1]);
 
-    expect(result.messages![1].data).toHaveProperty(
+    expect(supervisorMessage.data).toHaveProperty(
       "message",
-      "If you are not done, please provide an invocation, otherwise return done.",
+      "If you are not done, please provide an invocation, otherwise return done."
     );
   });
 
@@ -181,20 +178,20 @@ describe("handleModelCall", () => {
     expect(result.status).toBe("running");
 
     expect(result.messages![0]).toHaveProperty("type", "agent-invalid");
-    assertGenericMessage(result.messages![0]);
-    expect(result.messages![0].data).toHaveProperty(
+    const invalidMessage = assertMessageOfType("agent-invalid", result.messages![0]);
+    expect(invalidMessage.data).toHaveProperty(
       "details",
       expect.objectContaining({
         done: true,
-      }),
+      })
     );
 
     expect(result.messages![1]).toHaveProperty("type", "supervisor");
 
-    assertGenericMessage(result.messages![1]);
-    expect(result.messages![1].data).toHaveProperty(
+    const supervisorMessage = assertMessageOfType("supervisor", result.messages![1]);
+    expect(supervisorMessage.data).toHaveProperty(
       "message",
-      "Please provide a final result or a reason for stopping.",
+      "Please provide a final result or a reason for stopping."
     );
   });
 
@@ -205,9 +202,7 @@ describe("handleModelCall", () => {
       throw error;
     };
 
-    expect(
-      handleModelCall(state, model, errorFindRelevantTools),
-    ).rejects.toThrow(error);
+    expect(handleModelCall(state, model, errorFindRelevantTools)).rejects.toThrow(error);
   });
 
   it("should abort if a cycle is detected", async () => {
@@ -220,9 +215,7 @@ describe("handleModelCall", () => {
         runId: workflow.id,
         type: "agent" as const,
         data: {
-          invocations: [
-            { done: false, learning: "I learnt some stuff" } as any,
-          ],
+          invocations: [{ done: false, learning: "I learnt some stuff" } as any],
         },
       });
       messages.push({
@@ -236,9 +229,9 @@ describe("handleModelCall", () => {
       });
     }
 
-    expect(
-      handleModelCall({ ...state, messages }, model, findRelevantTools),
-    ).rejects.toThrow("Detected cycle in workflow.");
+    expect(handleModelCall({ ...state, messages }, model, findRelevantTools)).rejects.toThrow(
+      "Detected cycle in workflow."
+    );
   });
 
   it("should trigger supervisor if parsing fails", async () => {
@@ -258,17 +251,17 @@ describe("handleModelCall", () => {
     expect(result.status).toBe("running");
 
     expect(result.messages![0]).toHaveProperty("type", "agent-invalid");
-    assertGenericMessage(result.messages![0]);
-    expect(result.messages![0].data).toHaveProperty("details");
+    const invalidMessage = assertMessageOfType("agent-invalid", result.messages![0]);
+    expect(invalidMessage.data).toHaveProperty("details");
 
     expect(result.messages![1]).toHaveProperty("type", "supervisor");
-    assertGenericMessage(result.messages![1]);
+    const supervisorMessage = assertMessageOfType("supervisor", result.messages![1]);
 
-    expect(result.messages![1].data).toHaveProperty(
+    expect(supervisorMessage.data).toHaveProperty(
       "message",
-      expect.stringContaining("Provided object was invalid, check your input"),
+      expect.stringContaining("Provided object was invalid, check your input")
     );
-    expect(result.messages![1].data.details).toHaveProperty("errors");
+    expect(supervisorMessage.data.details).toHaveProperty("errors");
   });
 
   // Edge case where the model trys to call a tool (unbound) rather than returning it through `invocations` array.
@@ -305,9 +298,9 @@ describe("handleModelCall", () => {
       expect(result.status).toBe("running");
 
       expect(result.messages![0]).toHaveProperty("type", "agent");
-      assertAgentMessage(result.messages![0]);
+      const agentMessage = assertMessageOfType("agent", result.messages![0]);
 
-      expect(result.messages![0].data).toHaveProperty("invocations", [
+      expect(agentMessage.data).toHaveProperty("invocations", [
         {
           id: expect.any(String),
           toolName: "notify",
@@ -360,9 +353,9 @@ describe("handleModelCall", () => {
       expect(result.status).toBe("running");
 
       expect(result.messages![0]).toHaveProperty("type", "agent");
-      assertAgentMessage(result.messages![0]);
+      const agentMessage = assertMessageOfType("agent", result.messages![0]);
 
-      expect(result.messages![0].data).toHaveProperty("invocations", [
+      expect(agentMessage.data).toHaveProperty("invocations", [
         {
           id: expect.any(String),
           toolName: "notify",

--- a/control-plane/src/modules/workflows/agent/nodes/tool-call.ts
+++ b/control-plane/src/modules/workflows/agent/nodes/tool-call.ts
@@ -1,13 +1,10 @@
 import { ulid } from "ulid";
-import {
-  AgentError,
-  InvalidJobArgumentsError,
-} from "../../../../utilities/errors";
+import { AgentError, InvalidJobArgumentsError } from "../../../../utilities/errors";
 import * as events from "../../../observability/events";
 import { logger } from "../../../observability/logger";
 import { addAttributes, withSpan } from "../../../observability/tracer";
 import { trackCustomerTelemetry } from "../../../track-customer-telemetry";
-import { AgentMessage, assertAgentMessage } from "../../workflow-messages";
+import { AgentMessage, assertMessageOfType } from "../../workflow-messages";
 import { Run } from "../../workflows";
 import { ToolFetcher } from "../agent";
 import { WorkflowAgentState } from "../state";
@@ -16,14 +13,12 @@ import { AgentTool, AgentToolInputError } from "../tool";
 
 export const TOOL_CALL_NODE_NAME = "action";
 
-export const handleToolCalls = (
-  state: WorkflowAgentState,
-  getTool: ToolFetcher,
-) => withSpan("workflow.toolCalls", () => _handleToolCalls(state, getTool));
+export const handleToolCalls = (state: WorkflowAgentState, getTool: ToolFetcher) =>
+  withSpan("workflow.toolCalls", () => _handleToolCalls(state, getTool));
 
 const _handleToolCalls = async (
   state: WorkflowAgentState,
-  getTool: ToolFetcher,
+  getTool: ToolFetcher
 ): Promise<Partial<WorkflowAgentState>> => {
   // When we recieve parallel tool calls, we will receive a number of ToolMessage's
   // after the last AIMessage (The actual function call).
@@ -33,12 +28,9 @@ const _handleToolCalls = async (
 
   const resolvedToolsCalls = new Set<string>();
   while (lastMessage.type === "invocation-result") {
-    logger.info(
-      "Found invocation-result message, finding last non-invocation message",
-      {
-        toolCallId: lastMessage.data.id,
-      },
-    );
+    logger.info("Found invocation-result message, finding last non-invocation message", {
+      toolCallId: lastMessage.data.id,
+    });
 
     // Keep track of the tool calls which have already resolved
     resolvedToolsCalls.add(lastMessage.data.id);
@@ -54,21 +46,18 @@ const _handleToolCalls = async (
     lastMessage = message;
   }
 
-  assertAgentMessage(lastMessage);
+  const agentMessage = assertMessageOfType("agent", lastMessage);
 
-  if (
-    !lastMessage.data.invocations ||
-    lastMessage.data.invocations.length === 0
-  ) {
+  if (!agentMessage.data.invocations || agentMessage.data.invocations.length === 0) {
     logger.error("Expected a tool call", { lastMessage });
     throw new AgentError("Expected a tool call");
   }
 
   const toolResults = await Promise.all(
-    lastMessage.data.invocations
+    agentMessage.data.invocations
       // Filter out any tool_calls which have already resolvedd
-      .filter((toolCall) => !resolvedToolsCalls.has(toolCall.id ?? ""))
-      .map((toolCall) => handleToolCall(toolCall, state.workflow, getTool)),
+      .filter(toolCall => !resolvedToolsCalls.has(toolCall.id ?? ""))
+      .map(toolCall => handleToolCall(toolCall, state.workflow, getTool))
   );
 
   return toolResults.reduce(
@@ -77,10 +66,10 @@ const _handleToolCalls = async (
       if (result.waitingJobs) acc.waitingJobs!.push(...result.waitingJobs);
       if (result.result) {
         if (!!acc.result && !!result.result && result.result !== acc.result) {
-          logger.error(
-            "Multiple tools returned different results. Last one will be used.",
-            { result, accResult: acc.result },
-          );
+          logger.error("Multiple tools returned different results. Last one will be used.", {
+            result,
+            accResult: acc.result,
+          });
         }
 
         acc.result = result.result;
@@ -93,30 +82,26 @@ const _handleToolCalls = async (
       waitingJobs: [],
       status: "running",
       result: undefined,
-    },
+    }
   );
 };
 
 const handleToolCall = (
   toolCall: Required<AgentMessage["data"]>["invocations"][number],
   workflow: Run,
-  getTool: ToolFetcher,
+  getTool: ToolFetcher
 ) =>
-  withSpan(
-    "workflow.toolCall",
-    () => _handleToolCall(toolCall, workflow, getTool),
-    {
-      attributes: {
-        "tool.name": toolCall.toolName,
-        "tool.call.id": toolCall.id,
-      },
+  withSpan("workflow.toolCall", () => _handleToolCall(toolCall, workflow, getTool), {
+    attributes: {
+      "tool.name": toolCall.toolName,
+      "tool.call.id": toolCall.id,
     },
-  );
+  });
 
 const _handleToolCall = async (
   toolCall: Required<AgentMessage["data"]>["invocations"][number],
   workflow: Run,
-  getTool: ToolFetcher,
+  getTool: ToolFetcher
 ): Promise<Partial<WorkflowAgentState>> => {
   logger.info("Executing tool call");
 

--- a/control-plane/src/modules/workflows/router.ts
+++ b/control-plane/src/modules/workflows/router.ts
@@ -19,7 +19,6 @@ import { timeline } from "../timeline";
 import { getRunsByMetadata } from "./metadata";
 import {
   addMessageAndResume,
-  assertRunReady,
   createRetry,
   createRun,
   deleteRun,
@@ -60,7 +59,10 @@ export const runsRouter = initServer().router(
 
       return {
         status: 200,
-        body: workflow,
+        body: {
+          ...workflow,
+          result: workflow.result ?? null,
+        },
       };
     },
     createRun: async request => {

--- a/control-plane/src/modules/workflows/workflow-messages.ts
+++ b/control-plane/src/modules/workflows/workflow-messages.ts
@@ -1,55 +1,48 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { and, desc, eq, gt, InferSelectModel, ne, sql } from "drizzle-orm";
+import { ulid } from "ulid";
 import { z } from "zod";
-import {
-  agentDataSchema,
-  genericMessageDataSchema,
-  messageDataSchema,
-  resultDataSchema,
-} from "../contract";
+import { unifiedMessageDataSchema } from "../contract";
 import { db, RunMessageMetadata, workflowMessages } from "../data";
 import { events } from "../observability/events";
 import { logger } from "../observability/logger";
 import { resumeRun } from "./workflows";
-import { ulid } from "ulid";
 
-export type MessageData = z.infer<typeof messageDataSchema>;
+export type TypedMessage = z.infer<typeof unifiedMessageDataSchema>;
 
-export type TypedMessage = AgentMessage | InvocationResultMessage | GenericMessage;
+export type TypedMessageWithMeta = {
+  id: string;
+  data: TypedMessage;
+  createdAt: Date;
+  pending: boolean;
+  displayableContext: Record<string, string> | null;
+};
 
 /**
  * A structured response from the agent.
  */
-export type AgentMessage = {
-  data: z.infer<typeof agentDataSchema>;
-  type: "agent";
-};
+export type AgentMessage = Extract<TypedMessage, { type: "agent" }>;
 
 /**
  * The result of a tool call.
  */
-export type InvocationResultMessage = {
-  data: z.infer<typeof resultDataSchema>;
-  type: "invocation-result";
-};
+export type InvocationResultMessage = Extract<TypedMessage, { type: "invocation-result" }>;
 
 /**
  * A generic message container.
  */
-export type GenericMessage = {
-  data: z.infer<typeof genericMessageDataSchema>;
-  type: "human" | "template" | "supervisor" | "agent-invalid";
-};
+export type GenericMessage = Extract<
+  TypedMessage,
+  { type: "human" | "template" | "supervisor" | "agent-invalid" }
+>;
 
-export type RunMessage = {
+export type RunMessage = TypedMessage & {
   id: string;
-  data: InferSelectModel<typeof workflowMessages>["data"];
-  type: InferSelectModel<typeof workflowMessages>["type"];
   clusterId: string;
   runId: string;
   createdAt: Date;
   updatedAt?: Date | null;
-} & TypedMessage;
+};
 
 export const insertRunMessage = async ({
   clusterId,
@@ -138,7 +131,7 @@ export const getRunMessagesForDisplay = async ({
   runId: string;
   last?: number;
   after?: string;
-}) => {
+}): Promise<TypedMessageWithMeta[]> => {
   const messages = await db
     .select({
       id: workflowMessages.id,
@@ -181,10 +174,28 @@ export const getRunMessagesForDisplay = async ({
       return message;
     })
     .map(message => {
-      validateMessage(message);
+      const { success, data, error } = unifiedMessageDataSchema.safeParse({
+        type: message.type,
+        data: message.data,
+      });
+
+      const messageWithType = !success
+        ? {
+            type: "supervisor" as const,
+            data: {
+              message: "Invalid message data",
+              details: {
+                error: error?.message,
+              },
+            },
+          }
+        : data;
 
       return {
-        ...message,
+        id: message.id,
+        data: messageWithType,
+        createdAt: message.createdAt,
+        pending: false,
         displayableContext: message.metadata?.displayable ?? null,
       };
     });
@@ -332,79 +343,40 @@ export const toAnthropicMessage = (message: TypedMessage): Anthropic.MessagePara
   }
 };
 
-const validateMessage = (message: Pick<RunMessage, "data" | "type">): TypedMessage => {
-  switch (message.type) {
-    case "agent": {
-      assertAgentMessage(message);
-      break;
-    }
-    case "invocation-result": {
-      assertResultMessage(message);
-      break;
-    }
-    default: {
-      assertGenericMessage(message);
-    }
+const validateMessage = (message: unknown) => {
+  const result = unifiedMessageDataSchema.safeParse(message);
+
+  if (!result.success) {
+    logger.error(`Invalid message type detected`, {
+      data: message,
+      result,
+      error: result.error,
+    });
+
+    throw new Error("Invalid message data");
   }
-  return message;
+
+  return result.data;
 };
 
 export function hasInvocations(message: AgentMessage): boolean {
   return (message.data.invocations && message.data.invocations.length > 0) ?? false;
 }
 
-export function assertAgentMessage(
-  message: Pick<RunMessage, "data" | "type">
-): asserts message is AgentMessage {
-  if (message.type !== "agent") {
-    throw new Error("Expected an AgentMessage");
-  }
-
-  const result = agentDataSchema.safeParse(message.data);
+export function assertMessageOfType<
+  T extends "agent" | "invocation-result" | "human" | "template" | "supervisor" | "agent-invalid",
+>(type: T, message: unknown) {
+  const result = unifiedMessageDataSchema.safeParse(message);
 
   if (!result.success) {
-    logger.error("Invalid AgentMessage data", {
-      data: message.data,
-      result,
-    });
-    throw new Error("Invalid AgentMessage data");
-  }
-}
-
-export function assertResultMessage(
-  message: Pick<RunMessage, "data" | "type">
-): asserts message is InvocationResultMessage {
-  if (message.type !== "invocation-result") {
-    throw new Error("Expected a InvocationResultMessage");
+    throw new Error("Invalid message data");
   }
 
-  const result = resultDataSchema.safeParse(message.data);
-
-  if (!result.success) {
-    logger.error("Invalid InvocationResultMessage data", {
-      data: message.data,
-      result,
-    });
-    throw new Error("Invalid InvocationResultMessage data");
-  }
-}
-
-export function assertGenericMessage(
-  message: Pick<RunMessage, "data" | "type">
-): asserts message is GenericMessage {
-  if (!["human", "template", "supervisor", "agent-invalid"].includes(message.type)) {
-    throw new Error("Expected a GenericMessage");
+  if (result.data.type !== type) {
+    throw new Error(`Expected a ${type} message. Got ${result.data.type}`);
   }
 
-  const result = genericMessageDataSchema.safeParse(message.data);
-
-  if (!result.success) {
-    logger.error("Invalid GenericMessage data", {
-      data: message.data,
-      result,
-    });
-    throw new Error("Invalid GenericMessage data");
-  }
+  return result.data as Extract<TypedMessage, { type: T }>;
 }
 
 export const lastAgentMessage = async ({
@@ -435,10 +407,8 @@ export const lastAgentMessage = async ({
     return;
   }
 
-  assertAgentMessage(result);
-  return result;
+  return assertMessageOfType("agent", result);
 };
-
 
 export const getMessageByReference = async (reference: string, clusterId: string) => {
   const [result] = await db
@@ -459,28 +429,22 @@ export const getMessageByReference = async (reference: string, clusterId: string
       )
     );
 
-  return result
-}
+  return result;
+};
 
 export const updateMessageReference = async ({
   externalReference,
   clusterId,
-  messageId
-}:
-  {
-    externalReference: string,
-    clusterId: string,
-    messageId: string
-  }) => {
+  messageId,
+}: {
+  externalReference: string;
+  clusterId: string;
+  messageId: string;
+}) => {
   await db
     .update(workflowMessages)
     .set({
       metadata: sql`COALESCE(${workflowMessages.metadata}, '{}')::jsonb || ${JSON.stringify({ externalReference })}::jsonb`,
     })
-    .where(
-      and(
-        eq(workflowMessages.cluster_id, clusterId),
-        eq(workflowMessages.id, messageId)
-      )
-    );
-}
+    .where(and(eq(workflowMessages.cluster_id, clusterId), eq(workflowMessages.id, messageId)));
+};

--- a/control-plane/src/modules/workflows/workflows.ts
+++ b/control-plane/src/modules/workflows/workflows.ts
@@ -354,7 +354,7 @@ export const getWorkflowDetail = async ({
     // Current a workflow can have multiple "results".
     // For now, we just use the last result.
     // In the future, we will actually persist the workflow result.
-    result: agentMessage?.data?.result ?? null,
+    result: agentMessage?.type === "agent" ? agentMessage.data.result : null,
   };
 };
 

--- a/control-plane/src/utilities/cache.ts
+++ b/control-plane/src/utilities/cache.ts
@@ -13,7 +13,6 @@ export const createCache = <T>(namespace: symbol) => {
       const localResult = localCache.get<T>(key);
 
       if (localResult !== undefined) {
-        logger.info("Local cache hit", { key });
         return localResult;
       }
 
@@ -26,7 +25,6 @@ export const createCache = <T>(namespace: symbol) => {
       return undefined;
     },
     set: async (key: string, value: T, stdTTLSeconds: number) => {
-      logger.info("Local cache set", { key, value, stdTTLSeconds });
       localCache.set(key, value, stdTTLSeconds);
 
       if (stdTTLSeconds > 1000) {


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Unified message schema introduced for consistent message handling.

- Refactored message validation and parsing logic for robustness.

- Updated tests to align with the new schema and validation.

- Removed redundant logging and improved code formatting.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>contract.ts</strong><dd><code>Introduced unified message schema for message handling.</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/456/files#diff-b5950839f91929a72fdc1a19dbd99f3c7db3032893deb18743fc93deff2e34bc">+37/-32</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>data.ts</strong><dd><code>Updated message data type to use unified schema.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/456/files#diff-389a480d000c3f91c0ca76b0cacd863c9db8ded03e464a9df80b7e905d233a05">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Integrated unified schema in email message handling.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/456/files#diff-6338c186d160099dfc1a5bbf40f75e08318c49dfce050119dc3ce610377c6dcf">+42/-39</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Applied unified schema in Slack integration workflows.</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/456/files#diff-371db4e2ab9c97fb66d167e085aad6f537472811427c427967ef527f85dfa483">+100/-89</a></td>

</tr>

<tr>
  <td><strong>router.ts</strong><dd><code>Adjusted message assertion to use unified schema.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/456/files#diff-8ae44be4c7b96ed5ba871dae265ba5e854ab9c80720d80f8f6412ea560fe200a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tool-call.ts</strong><dd><code>Refactored tool-call logic to use unified schema.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/456/files#diff-49e348954902888cb75b23f781538f4a025c65e06f6e8f47fc842d63c8dd24d7">+25/-40</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>workflow-messages.ts</strong><dd><code>Centralized message validation and parsing with unified schema.</code></dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/456/files#diff-d30d2ee300da8f01f2a2a379b3556e1c28aa845d17d034477a2fde49341278c3">+71/-107</a></td>

</tr>

<tr>
  <td><strong>workflows.ts</strong><dd><code>Updated workflow detail logic for unified schema.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/456/files#diff-17e8112ac05d30dbcbdf5b549c08800a1a3f5dc79df9500931b34e7ac8c0dc25">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>agent.ai.test.ts</strong><dd><code>Updated agent tests to validate against unified schema.</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/456/files#diff-92d0bd743884a650d83217310bddaf7ab39b837586816830c277fa697ae2efc7">+44/-78</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>model-call.test.ts</strong><dd><code>Refactored model-call tests for schema validation.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/456/files#diff-6e31356bfc5e1a9ecf9d2a4edd2b7c5335538775753eb9ed55c737a70b3f9fbe">+39/-46</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>tool-call.test.ts</strong><dd><code>Enhanced tool-call tests with unified schema validation.</code>&nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/456/files#diff-e596637200bc08b2d9175f881e12b7bf6c9ac9242fb5e77e81b9af8e839fc631">+25/-34</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>router.ts</strong><dd><code>Adjusted workflow router to handle null results.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/456/files#diff-ec9592ce01e121f7ef9dfb72f9726dcb795c07245e6ad808a8621b96ae8667bc">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cache.ts</strong><dd><code>Removed redundant logging in cache utility.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/456/files#diff-297089dd545adde131a58ae9bdaf9da197dcbe8aea46013c1ea75e55b5f52323">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information