### PR TITLE
feat: Enforce custom auth userId value

### DIFF
--- a/app/app/clusters/[clusterId]/settings/details/page.tsx
+++ b/app/app/clusters/[clusterId]/settings/details/page.tsx
@@ -224,7 +224,7 @@ export default function DetailsPage({
                         Custom Auth
                       </FormLabel>
                       <FormDescription>
-                        Allow this cluster to be authenticated with <Link className="underline" href="https://docs.inferable.ai/pages/auth#customer-provided-secrets">custom authentication tokens</Link>.
+                        Allow this cluster to be authenticated with <Link className="underline" href="https://docs.inferable.ai/pages/custom-auth">custom authentication tokens</Link>.
                       </FormDescription>
                     </div>
                     <FormControl>

--- a/app/components/WorkflowList.tsx
+++ b/app/components/WorkflowList.tsx
@@ -84,7 +84,7 @@ export function RunList({ clusterId }: WorkflowListProps) {
       },
       query: {
         test: runFilters.test ? "true" : undefined,
-        userId: (runToggle === "mine" ? userId : undefined) ?? undefined,
+        userId: (runToggle === "mine" ? `clerk:${userId}` : undefined) ?? undefined,
         limit: Math.min(limit, 500), // Ensure limit doesn't exceed 500
         configId: runFilters.configId,
       },

--- a/control-plane/drizzle/0200_organic_terror.sql
+++ b/control-plane/drizzle/0200_organic_terror.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "workflows" DROP COLUMN IF EXISTS "custom_auth_token";

--- a/control-plane/drizzle/meta/0200_snapshot.json
+++ b/control-plane/drizzle/meta/0200_snapshot.json
@@ -1,0 +1,1658 @@
+{
+  "id": "74904df9-4450-4adf-81d9-496efbaa89ed",
+  "prevId": "2956a99d-e13d-43ff-824a-f3f8dc863d24",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.analytics_snapshots": {
+      "name": "analytics_snapshots",
+      "schema": "",
+      "columns": {
+        "data": {
+          "name": "data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "analytics_snapshots_pkey": {
+          "name": "analytics_snapshots_pkey",
+          "columns": [
+            "timestamp"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_secret_hash_index": {
+          "name": "api_keys_secret_hash_index",
+          "columns": [
+            {
+              "expression": "secret_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_cluster_id_clusters_id_fk": {
+          "name": "api_keys_cluster_id_clusters_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "api_keys_cluster_id_id_pk": {
+          "name": "api_keys_cluster_id_id_pk",
+          "columns": [
+            "cluster_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.blobs": {
+      "name": "blobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "encoding": {
+          "name": "encoding",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blobs_cluster_id_job_id_jobs_cluster_id_id_fk": {
+          "name": "blobs_cluster_id_job_id_jobs_cluster_id_id_fk",
+          "tableFrom": "blobs",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "cluster_id",
+            "job_id"
+          ],
+          "columnsTo": [
+            "cluster_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "blobs_cluster_id_workflow_id_workflows_cluster_id_id_fk": {
+          "name": "blobs_cluster_id_workflow_id_workflows_cluster_id_id_fk",
+          "tableFrom": "blobs",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "cluster_id",
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "cluster_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "blobs_cluster_id_id_pk": {
+          "name": "blobs_cluster_id_id_pk",
+          "columns": [
+            "cluster_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.clusters": {
+      "name": "clusters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "debug": {
+          "name": "debug",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enable_custom_auth": {
+          "name": "enable_custom_auth",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "handle_custom_auth_function": {
+          "name": "handle_custom_auth_function",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default_handleCustomAuth'"
+        },
+        "enable_run_configs": {
+          "name": "enable_run_configs",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enable_knowledgebase": {
+          "name": "enable_knowledgebase",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_context": {
+          "name": "additional_context",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clusters_id_org_index": {
+          "name": "clusters_id_org_index",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.embeddings": {
+      "name": "embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_1024": {
+          "name": "embedding_1024",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_data_hash": {
+          "name": "raw_data_hash",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "embedding1024Index": {
+          "name": "embedding1024Index",
+          "columns": [
+            {
+              "expression": "embedding_1024",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "embeddingsLookupIndex": {
+          "name": "embeddingsLookupIndex",
+          "columns": [
+            {
+              "expression": "cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "raw_data_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "embeddings_cluster_id_id_type_pk": {
+          "name": "embeddings_cluster_id_id_type_pk",
+          "columns": [
+            "cluster_id",
+            "id",
+            "type"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "machine_id": {
+          "name": "machine_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_fn": {
+          "name": "target_fn",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_type": {
+          "name": "result_type",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_usage_input": {
+          "name": "token_usage_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_usage_output": {
+          "name": "token_usage_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attention_level": {
+          "name": "attention_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "meta": {
+          "name": "meta",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        }
+      },
+      "indexes": {
+        "timeline_index": {
+          "name": "timeline_index",
+          "columns": [
+            {
+              "expression": "cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attention_level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.integrations": {
+      "name": "integrations",
+      "schema": "",
+      "columns": {
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "toolhouse": {
+          "name": "toolhouse",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "langfuse": {
+          "name": "langfuse",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tavily": {
+          "name": "tavily",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valtown": {
+          "name": "valtown",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack": {
+          "name": "slack",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "integrations_cluster_id_clusters_id_fk": {
+          "name": "integrations_cluster_id_clusters_id_fk",
+          "tableFrom": "integrations",
+          "tableTo": "clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "integrations_pkey": {
+          "name": "integrations_pkey",
+          "columns": [
+            "cluster_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_fn": {
+          "name": "target_fn",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_args": {
+          "name": "target_args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_key": {
+          "name": "cache_key",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_type": {
+          "name": "result_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executing_machine_id": {
+          "name": "executing_machine_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remaining_attempts": {
+          "name": "remaining_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resulted_at": {
+          "name": "resulted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_retrieved_at": {
+          "name": "last_retrieved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "function_execution_time_ms": {
+          "name": "function_execution_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeout_interval_seconds": {
+          "name": "timeout_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 300
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_context": {
+          "name": "auth_context",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_context": {
+          "name": "run_context",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_requested": {
+          "name": "approval_requested",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approved": {
+          "name": "approved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clusterServiceStatusIndex": {
+          "name": "clusterServiceStatusIndex",
+          "columns": [
+            {
+              "expression": "cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "service",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clusterServiceStatusFnIndex": {
+          "name": "clusterServiceStatusFnIndex",
+          "columns": [
+            {
+              "expression": "cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "service",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_fn",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "jobs_cluster_id_id": {
+          "name": "jobs_cluster_id_id",
+          "columns": [
+            "cluster_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "jobs_id_unique": {
+          "name": "jobs_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "public.machines": {
+      "name": "machines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_ping_at": {
+          "name": "last_ping_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sdk_version": {
+          "name": "sdk_version",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sdk_language": {
+          "name": "sdk_language",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "machines_id_cluster_id": {
+          "name": "machines_id_cluster_id",
+          "columns": [
+            "id",
+            "cluster_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.prompt_templates": {
+      "name": "prompt_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initial_prompt": {
+          "name": "initial_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attached_functions": {
+          "name": "attached_functions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "structured_output": {
+          "name": "structured_output",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_schema": {
+          "name": "input_schema",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_templates_cluster_id_clusters_id_fk": {
+          "name": "prompt_templates_cluster_id_clusters_id_fk",
+          "tableFrom": "prompt_templates",
+          "tableTo": "clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "prompt_templates_pkey": {
+          "name": "prompt_templates_pkey",
+          "columns": [
+            "cluster_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.services": {
+      "name": "services",
+      "schema": "",
+      "columns": {
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "queue_url": {
+          "name": "queue_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition": {
+          "name": "definition",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "services_cluster_id_clusters_id_fk": {
+          "name": "services_cluster_id_clusters_id_fk",
+          "tableFrom": "services",
+          "tableTo": "clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "services_cluster_id_service": {
+          "name": "services_cluster_id_service",
+          "columns": [
+            "cluster_id",
+            "service"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.tool_metadata": {
+      "name": "tool_metadata",
+      "schema": "",
+      "columns": {
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "function_name": {
+          "name": "function_name",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_defined_context": {
+          "name": "user_defined_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_keys": {
+          "name": "result_keys",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tool_metadata_cluster_id_clusters_id_fk": {
+          "name": "tool_metadata_cluster_id_clusters_id_fk",
+          "tableFrom": "tool_metadata",
+          "tableTo": "clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tool_metadata_pkey": {
+          "name": "tool_metadata_pkey",
+          "columns": [
+            "cluster_id",
+            "service",
+            "function_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.versioned_entities": {
+      "name": "versioned_entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "versioned_entities_pkey": {
+          "name": "versioned_entities_pkey",
+          "columns": [
+            "cluster_id",
+            "id",
+            "type",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.workflow_messages": {
+      "name": "workflow_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_messages_workflow_id_cluster_id_workflows_id_cluster_id_fk": {
+          "name": "workflow_messages_workflow_id_cluster_id_workflows_id_cluster_id_fk",
+          "tableFrom": "workflow_messages",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflow_id",
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id",
+            "cluster_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workflow_messages_cluster_id_workflow_id_id": {
+          "name": "workflow_messages_cluster_id_workflow_id_id",
+          "columns": [
+            "cluster_id",
+            "workflow_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.workflow_metadata": {
+      "name": "workflow_metadata",
+      "schema": "",
+      "columns": {
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workflowMetadataIndex": {
+          "name": "workflowMetadataIndex",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_metadata_workflow_id_cluster_id_workflows_id_cluster_id_fk": {
+          "name": "workflow_metadata_workflow_id_cluster_id_workflows_id_cluster_id_fk",
+          "tableFrom": "workflow_metadata",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflow_id",
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id",
+            "cluster_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workflow_metadata_cluster_id_workflow_id_key": {
+          "name": "workflow_metadata_cluster_id_workflow_id_key",
+          "columns": [
+            "cluster_id",
+            "workflow_id",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.workflows": {
+      "name": "workflows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_function": {
+          "name": "result_function",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_schema": {
+          "name": "result_schema",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_identifier": {
+          "name": "model_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debug": {
+          "name": "debug",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "attached_functions": {
+          "name": "attached_functions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "test": {
+          "name": "test",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "test_mocks": {
+          "name": "test_mocks",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::json"
+        },
+        "feedback_comment": {
+          "name": "feedback_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_score": {
+          "name": "feedback_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_version": {
+          "name": "config_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_traces": {
+          "name": "reasoning_traces",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "interactive": {
+          "name": "interactive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_summarization": {
+          "name": "enable_summarization",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enable_result_grounding": {
+          "name": "enable_result_grounding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auth_context": {
+          "name": "auth_context",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflows_cluster_id_clusters_id_fk": {
+          "name": "workflows_cluster_id_clusters_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workflows_cluster_id_id": {
+          "name": "workflows_cluster_id_id",
+          "columns": [
+            "cluster_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/control-plane/drizzle/meta/_journal.json
+++ b/control-plane/drizzle/meta/_journal.json
@@ -1394,6 +1394,13 @@
       "when": 1735591942949,
       "tag": "0199_curious_mach_iv",
       "breakpoints": true
+    },
+    {
+      "idx": 200,
+      "version": "7",
+      "when": 1735853703261,
+      "tag": "0200_organic_terror",
+      "breakpoints": true
     }
   ]
 }

--- a/control-plane/src/modules/auth/auth.test.ts
+++ b/control-plane/src/modules/auth/auth.test.ts
@@ -513,13 +513,13 @@ describe("extractCustomAuthState", () => {
 
     expect(result).toMatchObject({
       type: "custom",
-      entityId: "someValue",
+      entityId: "custom:someValue",
       organizationId: owner.organizationId,
       clusterId: owner.clusterId,
       canAccess: expect.any(Function),
       token: "abc123",
       context: {
-        someAuthValue: "someValue",
+        userId: "someValue",
       },
     });
 
@@ -594,7 +594,7 @@ describe("extractCustomAuthState", () => {
 
         const run = await createRun({
           clusterId: owner.clusterId,
-          customAuthToken: "abc123",
+          userId: "custom:someValue",
         });
 
         const result = await extractCustomAuthState(
@@ -618,7 +618,6 @@ describe("extractCustomAuthState", () => {
 
         const run = await createRun({
           clusterId: owner.clusterId,
-          customAuthToken: "abc123",
         });
 
         const result = await extractCustomAuthState(
@@ -666,7 +665,7 @@ describe("extractCustomAuthState", () => {
       it("should succeed if run is custom authenticated", async () => {
         const run = await createRun({
           clusterId: owner.clusterId,
-          customAuthToken: "abc123",
+          userId: "custom:someValue",
         });
 
         mockCustomAuth.verify.mockResolvedValue({
@@ -691,7 +690,6 @@ describe("extractCustomAuthState", () => {
       it("should throw if customer authenticated token doesn't match", async () => {
         const run = await createRun({
           clusterId: owner.clusterId,
-          customAuthToken: "abc123",
         });
 
         mockCustomAuth.verify.mockResolvedValue({

--- a/control-plane/src/modules/auth/auth.test.ts
+++ b/control-plane/src/modules/auth/auth.test.ts
@@ -506,13 +506,14 @@ describe("extractCustomAuthState", () => {
 
   it("should extract ApiKeyAuth from valid API secret", async () => {
     mockCustomAuth.verify.mockResolvedValue({
-      someAuthValue: "someValue",
+      userId: "someValue",
     });
 
     const result = await extractCustomAuthState("abc123", owner.clusterId);
 
     expect(result).toMatchObject({
       type: "custom",
+      entityId: "someValue",
       organizationId: owner.organizationId,
       clusterId: owner.clusterId,
       canAccess: expect.any(Function),
@@ -534,7 +535,7 @@ describe("extractCustomAuthState", () => {
     });
 
     mockCustomAuth.verify.mockResolvedValue({
-      someAuthValue: "someValue",
+      userId: "someValue",
     });
 
     await expect(extractCustomAuthState("abc123", owner.clusterId)).rejects.toThrow("Custom auth is not enabled for this cluster");
@@ -544,7 +545,7 @@ describe("extractCustomAuthState", () => {
   describe("isUser", () => {
     it("should throw", async () => {
       mockCustomAuth.verify.mockResolvedValue({
-        someAuthValue: "someValue",
+        userId: "someValue",
       });
 
       const result = await extractCustomAuthState("abc123", owner.clusterId);
@@ -557,7 +558,7 @@ describe("extractCustomAuthState", () => {
     describe("cluster", () => {
       it("should succeed for same cluster", async () => {
         mockCustomAuth.verify.mockResolvedValue({
-          someAuthValue: "someValue",
+          userId: "someValue",
         });
 
         const result = await extractCustomAuthState(
@@ -571,7 +572,7 @@ describe("extractCustomAuthState", () => {
 
       it("should throw for different cluster", async () => {
         mockCustomAuth.verify.mockResolvedValue({
-          someAuthValue: "someValue",
+          userId: "someValue",
         });
 
         const result = await extractCustomAuthState(
@@ -588,7 +589,7 @@ describe("extractCustomAuthState", () => {
       // Custom auth can access runs
       it("should succeed if run is custom authenticated", async () => {
         mockCustomAuth.verify.mockResolvedValue({
-          someAuthValue: "someValue",
+          userId: "someValue",
         });
 
         const run = await createRun({
@@ -612,7 +613,7 @@ describe("extractCustomAuthState", () => {
 
       it("should throw if custom authenticated token doesn't match", async () => {
         mockCustomAuth.verify.mockResolvedValue({
-          someAuthValue: "someValue",
+          userId: "someValue",
         });
 
         const run = await createRun({
@@ -636,7 +637,7 @@ describe("extractCustomAuthState", () => {
 
       it("should throw if run is not custom authenticated", async () => {
         mockCustomAuth.verify.mockResolvedValue({
-          someAuthValue: "someValue",
+          userId: "someValue",
         });
 
         const run = await createRun({
@@ -669,7 +670,7 @@ describe("extractCustomAuthState", () => {
         });
 
         mockCustomAuth.verify.mockResolvedValue({
-          someAuthValue: "someValue",
+          userId: "someValue",
         });
 
         const result = await extractCustomAuthState(
@@ -694,7 +695,7 @@ describe("extractCustomAuthState", () => {
         });
 
         mockCustomAuth.verify.mockResolvedValue({
-          someAuthValue: "someValue",
+          userId: "someValue",
         });
 
         const result = await extractCustomAuthState(
@@ -717,7 +718,7 @@ describe("extractCustomAuthState", () => {
         });
 
         mockCustomAuth.verify.mockResolvedValue({
-          someAuthValue: "someValue",
+          userId: "someValue",
         });
 
         const result = await extractCustomAuthState(
@@ -739,7 +740,7 @@ describe("extractCustomAuthState", () => {
       // Customer Provided auth can not manage cluster
       it("should throw", async () => {
         mockCustomAuth.verify.mockResolvedValue({
-          someAuthValue: "someValue",
+          userId: "someValue",
         });
 
         const result = await extractCustomAuthState(
@@ -756,7 +757,7 @@ describe("extractCustomAuthState", () => {
       // Customer Provided auth can not manage templates
       it("should throw", async () => {
         mockCustomAuth.verify.mockResolvedValue({
-          someAuthValue: "someValue",
+          userId: "someValue",
         });
 
         const result = await extractCustomAuthState(
@@ -778,7 +779,7 @@ describe("extractCustomAuthState", () => {
     describe("cluster", () => {
       it("should throw", async () => {
         mockCustomAuth.verify.mockResolvedValue({
-          someAuthValue: "someValue",
+          userId: "someValue",
         });
 
         const result = await extractCustomAuthState(
@@ -793,7 +794,7 @@ describe("extractCustomAuthState", () => {
       // Customer provided auth cannot create templates
       it("should throw", async () => {
         mockCustomAuth.verify.mockResolvedValue({
-          someAuthValue: "someValue",
+          userId: "someValue",
         });
 
         const result = await extractCustomAuthState(
@@ -808,7 +809,7 @@ describe("extractCustomAuthState", () => {
       // Customer provided auth can create runs
       it("should succeed", async () => {
         mockCustomAuth.verify.mockResolvedValue({
-          someAuthValue: "someValue",
+          userId: "someValue",
         });
 
         const result = await extractCustomAuthState(

--- a/control-plane/src/modules/auth/auth.test.ts
+++ b/control-plane/src/modules/auth/auth.test.ts
@@ -276,7 +276,7 @@ describe("extractAuthState", () => {
 
       const result = await extractAuthState("");
       expect(result).toMatchObject({
-        entityId: "cluster_1",
+        entityId: "clerk:cluster_1",
         organizationId: "org_1",
         organizationRole: "org:member",
         canAccess: expect.any(Function),
@@ -296,7 +296,7 @@ describe("extractAuthState", () => {
 
       const result = await extractAuthState("");
       expect(result).toMatchObject({
-        entityId: owner.userId,
+        entityId: `clerk:${owner.userId}`,
         organizationId: owner.organizationId,
         organizationRole: "org:member",
         canAccess: expect.any(Function),
@@ -337,7 +337,7 @@ describe("extractAuthState", () => {
 
         owner1AuthState = await extractAuthState("");
         expect(owner1AuthState).toMatchObject({
-          entityId: owner1.userId,
+          entityId: `clerk:${owner1.userId}`,
           organizationId: owner1.organizationId,
           organizationRole: "org:member",
           canAccess: expect.any(Function),
@@ -353,7 +353,7 @@ describe("extractAuthState", () => {
 
         owner2AuthState = await extractAuthState("");
         expect(owner2AuthState).toMatchObject({
-          entityId: owner2.userId,
+          entityId: `clerk:${owner2.userId}`,
           organizationId: owner2.organizationId,
           organizationRole: "org:member",
           canAccess: expect.any(Function),
@@ -426,7 +426,7 @@ describe("extractAuthState", () => {
 
           const ownerAuthState = await extractAuthState("");
           expect(ownerAuthState).toMatchObject({
-            entityId: admin.userId,
+            entityId: `clerk:${admin.userId}`,
             organizationId: admin.organizationId,
             organizationRole: "org:admin",
             canAccess: expect.any(Function),
@@ -464,7 +464,7 @@ describe("extractAuthState", () => {
 
           const ownerAuthState = await extractAuthState("");
           expect(ownerAuthState).toMatchObject({
-            entityId: admin.userId,
+            entityId: `clerk:${admin.userId}`,
             organizationId: admin.organizationId,
             organizationRole: "org:admin",
             canAccess: expect.any(Function),

--- a/control-plane/src/modules/auth/auth.ts
+++ b/control-plane/src/modules/auth/auth.ts
@@ -5,7 +5,7 @@ import { clusterExists, getClusterDetails } from "../cluster";
 import * as clusterAuth from "./cluster";
 import * as clerkAuth from "./clerk";
 import * as customAuth from "./custom";
-import { getRunCustomAuthToken, getRun } from "../workflows/workflows";
+import { getRun } from "../workflows/workflows";
 import { logger } from "../observability/logger";
 import { env } from "../../utilities/env";
 
@@ -361,7 +361,7 @@ export const extractCustomAuthState = async (
 
   return {
     type: "custom",
-    entityId: "CUSTOM_AUTH",
+    entityId: `custom:${context.userId}`,
     clusterId,
     organizationId: cluster.organization_id,
     token,
@@ -380,16 +380,16 @@ export const extractCustomAuthState = async (
       }
 
       if (opts.run) {
-        const existingToken = await getRunCustomAuthToken({
+        const existingRun = await getRun({
           clusterId: opts.run.clusterId,
           runId: opts.run.runId,
         });
 
-        if (!existingToken) {
-          throw new AuthenticationError("Custom auth can only access runs created by custom auth");
+        if (!existingRun) {
+          throw new AuthenticationError("Custom auth does not have access to this run");
         }
 
-        if (existingToken !== this.token) {
+        if (existingRun.userId !== this.entityId) {
           throw new AuthenticationError("Custom auth does not have access to this run");
         }
       }
@@ -417,16 +417,16 @@ export const extractCustomAuthState = async (
         throw new AuthenticationError("Custom auth can only manage runs");
       }
 
-      const existingToken = await getRunCustomAuthToken({
+      const existingRun = await getRun({
         clusterId: opts.run.clusterId,
         runId: opts.run.runId,
       });
 
-      if (!existingToken) {
-        throw new AuthenticationError("Custom auth can only access runs created by custom auth");
+      if (!existingRun) {
+        throw new AuthenticationError("Custom auth does not have access to this run");
       }
 
-      if (existingToken !== this.token) {
+      if (existingRun.userId !== this.entityId) {
         throw new AuthenticationError("Custom auth does not have access to this run");
       }
 

--- a/control-plane/src/modules/auth/cluster.ts
+++ b/control-plane/src/modules/auth/cluster.ts
@@ -4,12 +4,12 @@ import { randomBytes } from "crypto";
 import { logger } from "../observability/logger";
 import { createCache, hashFromSecret } from "../../utilities/cache";
 
-const apiKeyContextCache = createCache<{
+const clusterKeyContextCache = createCache<{
   clusterId: string;
   id: string;
   organizationId: string;
 }>(
-  Symbol("apiKeyContextCache"),
+  Symbol("clusterKeyContextCache"),
 );
 
 export const isApiSecret = (authorization: string): boolean =>
@@ -22,7 +22,7 @@ export const verify = async (
 > => {
   const secretHash = hashFromSecret(secret);
 
-  const cached = await apiKeyContextCache.get(secretHash);
+  const cached = await clusterKeyContextCache.get(secretHash);
 
   if (cached) {
     return cached;
@@ -56,7 +56,7 @@ export const verify = async (
     return undefined;
   }
 
-  await apiKeyContextCache.set(secretHash, {
+  await clusterKeyContextCache.set(secretHash, {
     clusterId: result.clusterId,
     id: result.id,
     organizationId: result.organizationId,

--- a/control-plane/src/modules/data.ts
+++ b/control-plane/src/modules/data.ts
@@ -288,7 +288,6 @@ export const workflows = pgTable(
     interactive: boolean("interactive").default(true).notNull(),
     enable_summarization: boolean("enable_summarization").default(false).notNull(),
     enable_result_grounding: boolean("enable_result_grounding").default(false).notNull(),
-    custom_auth_token: text("custom_auth_token"),
     auth_context: json("auth_context"),
     context: json("context"),
   },

--- a/control-plane/src/modules/workflows/metadata.ts
+++ b/control-plane/src/modules/workflows/metadata.ts
@@ -6,6 +6,7 @@ export const getRunsByMetadata = async ({
   key,
   value,
   limit = 10,
+  userId,
   configId,
 }: {
   clusterId: string;
@@ -13,6 +14,7 @@ export const getRunsByMetadata = async ({
   value: string;
   limit?: number;
   configId?: string;
+  userId?: string
 }) => {
   return await db
     .select({
@@ -36,6 +38,7 @@ export const getRunsByMetadata = async ({
         eq(workflowMetadata.key, key),
         eq(workflowMetadata.value, value),
         ...(configId ? [eq(workflows.config_id, configId)] : []),
+        ...(userId ? [eq(workflows.user_id, userId)] : []),
       ),
     )
     .rightJoin(workflows, eq(workflowMetadata.workflow_id, workflows.id))

--- a/control-plane/src/modules/workflows/router.ts
+++ b/control-plane/src/modules/workflows/router.ts
@@ -2,7 +2,7 @@ import { initServer } from "@ts-rest/fastify";
 import { dereferenceSync } from "dereference-json-schema";
 import { JsonSchemaInput } from "inferable/bin/types";
 import { ulid } from "ulid";
-import { NotFoundError } from "../../utilities/errors";
+import { AuthenticationError, NotFoundError } from "../../utilities/errors";
 import { getBlobsForJobs } from "../blobs";
 import { contract } from "../contract";
 import { getJobReferences } from "../jobs/jobs";
@@ -153,7 +153,7 @@ export const runsRouter = initServer().router(
 
         configId: runConfig?.id,
 
-        // Customer Auth
+        // Customer Auth context (In the future all auth types should inject context into the run)
         authContext: customAuth?.context,
 
         context: body.context,
@@ -284,10 +284,16 @@ export const runsRouter = initServer().router(
     },
     listRuns: async request => {
       const { clusterId } = request.params;
-      const { userId, test, limit, metadata, configId } = request.query;
+      const { test, limit, metadata, configId } = request.query;
+      let { userId } = request.query;
 
       const auth = request.request.getAuth();
       await auth.canAccess({ cluster: { clusterId } });
+
+      // Custom auth can only access their own Runs
+      if (auth.type === "custom") {
+        userId = auth.entityId
+      }
 
       if (metadata) {
         // ?meta=key:value
@@ -308,6 +314,7 @@ export const runsRouter = initServer().router(
           value,
           limit,
           configId,
+          userId
         });
 
         return {
@@ -315,6 +322,7 @@ export const runsRouter = initServer().router(
           body: result,
         };
       }
+
 
       const result = await getClusterWorkflows({
         clusterId,

--- a/control-plane/src/modules/workflows/router.ts
+++ b/control-plane/src/modules/workflows/router.ts
@@ -155,7 +155,6 @@ export const runsRouter = initServer().router(
 
         // Customer Auth
         authContext: customAuth?.context,
-        customAuthToken: customAuth?.token,
 
         context: body.context,
 

--- a/control-plane/src/modules/workflows/workflows.ts
+++ b/control-plane/src/modules/workflows/workflows.ts
@@ -658,25 +658,3 @@ export const createRetry = async ({ clusterId, runId }: { clusterId: string; run
     id: runId,
   });
 };
-
-export const getRunCustomAuthToken = async ({
-  clusterId,
-  runId,
-}: {
-  clusterId: string;
-  runId: string;
-}) => {
-  const [workflow] = await db
-    .select({
-      customAuthToken: workflows.custom_auth_token,
-    })
-    .from(workflows)
-    .where(and(eq(workflows.id, runId), eq(workflows.cluster_id, clusterId)))
-    .limit(1);
-
-  if (!workflow) {
-    throw new NotFoundError("Run not found");
-  }
-
-  return workflow.customAuthToken;
-};

--- a/control-plane/src/modules/workflows/workflows.ts
+++ b/control-plane/src/modules/workflows/workflows.ts
@@ -79,7 +79,6 @@ export const createRun = async ({
   reasoningTraces,
   enableSummarization,
   modelIdentifier,
-  customAuthToken,
   authContext,
   context,
   enableResultGrounding,
@@ -106,7 +105,6 @@ export const createRun = async ({
   reasoningTraces?: boolean;
   enableSummarization?: boolean;
   modelIdentifier?: ChatIdentifiers;
-  customAuthToken?: string;
   authContext?: unknown;
   context?: unknown;
   enableResultGrounding?: boolean;
@@ -144,7 +142,6 @@ export const createRun = async ({
           config_id: configId,
           config_version: configVersion,
           model_identifier: modelIdentifier,
-          custom_auth_token: customAuthToken,
           auth_context: authContext,
           context: context,
           enable_result_grounding: enableResultGrounding,
@@ -487,7 +484,6 @@ export const createRunWithMessage = async ({
   enableSummarization,
   modelIdentifier,
   onStatusChange,
-  customAuthToken,
   authContext,
   context,
   enableResultGrounding,
@@ -510,7 +506,6 @@ export const createRunWithMessage = async ({
     interactive,
     enableSummarization,
     modelIdentifier,
-    customAuthToken,
     authContext,
     context,
     enableResultGrounding,


### PR DESCRIPTION
Require that a cluster's `customAuthHandler` returns an object with key `userId` (Other keys are allowed with `z.passthrough()`).

This value is used as the Run's `userId` (prefixed with `custom:`) and validated for run ownership.

This allows for tokens to be refreshed while still providing access to the existing runs by allowing the `customAuthHandler` to provide the identity.


___

### **Description**
- Enforced `userId` as the key for custom authentication.

- Updated `extractCustomAuthState` to use `userId` consistently.

- Added schema validation for custom authentication results.

- Removed unused `getRunCustomAuthToken` function.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>auth.test.ts</strong><dd><code>Update tests for custom authentication changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

control-plane/src/modules/auth/auth.test.ts

<li>Updated tests to use <code>userId</code> instead of <code>someAuthValue</code>.<br> <li> Adjusted test cases to align with new <code>entityId</code> logic.


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/457/files#diff-f40fd8ed82088dc7bd0a1777bb344b48646a63aba3b3b4f4c5586136a9c7c07d">+17/-16</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>auth.ts</strong><dd><code>Refactor custom authentication logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

control-plane/src/modules/auth/auth.ts

<li>Replaced <code>entityId</code> value with <code>custom:${context.userId}</code>.<br> <li> Updated logic to validate <code>userId</code> for run access.<br> <li> Removed dependency on <code>getRunCustomAuthToken</code>.


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/457/files#diff-9e6b80fe44fcd1edc9d4312ff3aa46a248767bc5b60f3b1d17f51c23b62b65f3">+10/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>custom.ts</strong><dd><code>Add schema validation for custom auth results</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

control-plane/src/modules/auth/custom.ts

<li>Added <code>zod</code> schema for validating custom auth results.<br> <li> Integrated schema validation into the <code>verify</code> function.


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/457/files#diff-cecb27ac9fc1492896bbe25d07c3db65aa249d92751d07d17aa20948b401d86f">+17/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Cleanup</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workflows.ts</strong><dd><code>Remove unused custom auth token function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

control-plane/src/modules/workflows/workflows.ts

- Removed unused `getRunCustomAuthToken` function.


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/457/files#diff-17e8112ac05d30dbcbdf5b549c08800a1a3f5dc79df9500931b34e7ac8c0dc25">+0/-22</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information