### PR TITLE
feat: Make listMessages polling configurable

### DIFF
--- a/control-plane/src/modules/contract.ts
+++ b/control-plane/src/modules/contract.ts
@@ -664,8 +664,14 @@ export const definition = {
       authorization: z.string(),
     }),
     query: z.object({
+      waitTime: z.coerce
+        .number()
+        .min(0)
+        .max(20)
+        .default(0)
+        .describe("Time in seconds to keep the request open waiting for a response"),
       after: z.string().default("0"),
-      last: z.coerce.number().min(10).max(50).default(50),
+      limit: z.coerce.number().min(10).max(50).default(50),
     }),
     responses: {
       200: z.array(unifiedMessageDataSchema),

--- a/control-plane/src/modules/router.ts
+++ b/control-plane/src/modules/router.ts
@@ -286,7 +286,8 @@ export const router = initServer().router(contract, {
       clusterId,
       runId,
       after: request.query.after,
-      last: request.query.last,
+      limit: request.query.limit,
+      timeout: request.query.waitTime * 1000,
     });
 
     return {

--- a/control-plane/src/modules/workflows/workflow-messages.ts
+++ b/control-plane/src/modules/workflows/workflow-messages.ts
@@ -109,12 +109,12 @@ export const editHumanMessage = async ({
 export const getRunMessagesForDisplay = async ({
   clusterId,
   runId,
-  last = 50,
+  limit = 50,
   after = "0",
 }: {
   clusterId: string;
   runId: string;
-  last?: number;
+  limit?: number;
   after?: string;
 }): Promise<UnifiedMessage[]> => {
   const messages = await db
@@ -138,7 +138,7 @@ export const getRunMessagesForDisplay = async ({
         ne(workflowMessages.type, "result" as any)
       )
     )
-    .limit(last);
+    .limit(limit);
 
   return messages
     .map(message => {
@@ -187,21 +187,22 @@ export const getRunMessagesForDisplay = async ({
 export const getRunMessagesForDisplayWithPolling = async ({
   clusterId,
   runId,
-  last = 100,
+  timeout = 20_000,
+  limit = 100,
   after = "0",
 }: {
   clusterId: string;
   runId: string;
-  last?: number;
+  limit?: number;
   after?: string;
+  timeout?: number
 }): Promise<UnifiedMessage[]> => {
   let rowsCount = 0;
   const delay = 200;
-  const timeout = 20_000;
   const startTime = Date.now();
 
   do {
-    const messages = await getRunMessagesForDisplay({ clusterId, runId, last, after });
+    const messages = await getRunMessagesForDisplay({ clusterId, runId, limit, after });
     rowsCount = messages.length;
 
     if (rowsCount > 0) {
@@ -218,12 +219,12 @@ export const getRunMessagesForDisplayWithPolling = async ({
 export const getWorkflowMessages = async ({
   clusterId,
   runId,
-  last = 100,
+  limit = 100,
   after = "0",
 }: {
   clusterId: string;
   runId: string;
-  last?: number;
+  limit?: number;
   after?: string;
 }): Promise<UnifiedMessage[]> => {
   const messages = await db
@@ -245,7 +246,7 @@ export const getWorkflowMessages = async ({
         gt(workflowMessages.id, after)
       )
     )
-    .limit(last)
+    .limit(limit)
     .then(messages => messages.reverse());
 
   return messages

--- a/control-plane/src/modules/workflows/workflows.ts
+++ b/control-plane/src/modules/workflows/workflows.ts
@@ -562,7 +562,7 @@ export const assertRunReady = async (input: { runId: string; clusterId: string }
   const [lastMessage] = await getWorkflowMessages({
     clusterId: run.clusterId,
     runId: run.id,
-    last: 1,
+    limit: 1,
   });
 
   if (!lastMessage) {

--- a/sdk-react/src/contract.ts
+++ b/sdk-react/src/contract.ts
@@ -671,7 +671,7 @@ export const definition = {
         .default(0)
         .describe("Time in seconds to keep the request open waiting for a response"),
       after: z.string().default("0"),
-      last: z.coerce.number().min(10).max(50).default(50),
+      limit: z.coerce.number().min(10).max(50).default(50),
     }),
     responses: {
       200: z.array(unifiedMessageDataSchema),

--- a/sdk-react/src/contract.ts
+++ b/sdk-react/src/contract.ts
@@ -663,14 +663,20 @@ export const definition = {
     headers: z.object({
       authorization: z.string(),
     }),
+    query: z.object({
+      waitTime: z.coerce
+        .number()
+        .min(0)
+        .max(20)
+        .default(0)
+        .describe("Time in seconds to keep the request open waiting for a response"),
+      after: z.string().default("0"),
+      last: z.coerce.number().min(10).max(50).default(50),
+    }),
     responses: {
       200: z.array(unifiedMessageDataSchema),
       401: z.undefined(),
     },
-    query: z.object({
-      last: z.coerce.number().min(10).max(50).default(50),
-      after: z.string().default("0"),
-    }),
   },
   listRuns: {
     method: "GET",

--- a/sdk-react/src/hooks/useRun.ts
+++ b/sdk-react/src/hooks/useRun.ts
@@ -141,6 +141,7 @@ export function useRun<T extends z.ZodObject<any>>(
             params: { clusterId: inferable.clusterId, runId: runId },
             query: {
               after: lastMessageId.current ?? "0",
+              waitTime: 20,
             },
           }),
           inferable.client.getRun({


### PR DESCRIPTION
### **User description**
Allow `listMessages` to be used in a long or short polling capacity.

- Add `waitTime` query parameter to `listMessages` to enable long polling
- Rename `last` -> `limit`


#462 

___

### **PR Type**
Enhancement


___

### **Description**
- Added `waitTime` query parameter for long polling in `listMessages`.

- Renamed `last` parameter to `limit` for clarity.

- Updated related functions to support `waitTime` and `limit`.

- Adjusted SDK and hooks to align with new query parameters.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>contract.ts</strong><dd><code>Add `waitTime` and rename `last` to `limit`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

control-plane/src/modules/contract.ts

<li>Added <code>waitTime</code> query parameter for long polling.<br> <li> Renamed <code>last</code> parameter to <code>limit</code>.<br> <li> Updated query schema for <code>listMessages</code>.


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/461/files#diff-b5950839f91929a72fdc1a19dbd99f3c7db3032893deb18743fc93deff2e34bc">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>router.ts</strong><dd><code>Update router to handle `waitTime` and `limit`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

control-plane/src/modules/router.ts

<li>Passed <code>waitTime</code> and <code>limit</code> to <code>getRunMessagesForDisplayWithPolling</code>.<br> <li> Updated query parameter usage in router logic.


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/461/files#diff-8ae44be4c7b96ed5ba871dae265ba5e854ab9c80720d80f8f6412ea560fe200a">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>workflow-messages.ts</strong><dd><code>Refactor workflow message functions for `limit` and `timeout`</code></dd></summary>
<hr>

control-plane/src/modules/workflows/workflow-messages.ts

<li>Replaced <code>last</code> with <code>limit</code> in function parameters.<br> <li> Added <code>timeout</code> parameter for polling logic.<br> <li> Updated database queries to use <code>limit</code>.


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/461/files#diff-d30d2ee300da8f01f2a2a379b3556e1c28aa845d17d034477a2fde49341278c3">+11/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>workflows.ts</strong><dd><code>Update workflows to use `limit` parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

control-plane/src/modules/workflows/workflows.ts

<li>Replaced <code>last</code> with <code>limit</code> in <code>getWorkflowMessages</code> call.<br> <li> Adjusted function calls to align with new parameter naming.


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/461/files#diff-17e8112ac05d30dbcbdf5b549c08800a1a3f5dc79df9500931b34e7ac8c0dc25">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>contract.ts</strong><dd><code>Enhance SDK contract with `waitTime` and `limit`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sdk-react/src/contract.ts

<li>Added <code>waitTime</code> query parameter to <code>listMessages</code>.<br> <li> Renamed <code>last</code> to <code>limit</code> in query schema.


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/461/files#diff-2debbef73c457d313ad85be8655477cb543ec65fc1ec056b1b7e11b4ec3f20eb">+10/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>useRun.ts</strong><dd><code>Add `waitTime` to `useRun` hook for polling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sdk-react/src/hooks/useRun.ts

<li>Added <code>waitTime</code> parameter to <code>listMessages</code> query in hook.<br> <li> Updated hook logic to support long polling.


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/461/files#diff-5b0ce23033a7e6b1b9164c8ebdacd4f57a6526161c4318f84a97281db3e9c08e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information