### PR TITLE
fix: Add missing metadata to test messages in agent.ai.test.ts

### DIFF
--- a/control-plane/src/modules/workflows/agent/agent.ai.test.ts
+++ b/control-plane/src/modules/workflows/agent/agent.ai.test.ts
@@ -70,10 +70,12 @@ describe("Agent", () => {
       const outputState = await app.invoke({
         messages: [
           {
+            type: "human",
             data: {
               message: "echo the word 'hello'",
             },
-            type: "human",
+            id: "test-msg-1",
+            createdAt: new Date(),
           },
         ],
       });
@@ -112,10 +114,12 @@ describe("Agent", () => {
       const outputState = await app.invoke({
         messages: [
           {
+            type: "human",
             data: {
               message: "echo the word 'hello' and then the word 'goodbye'",
             },
-            type: "human",
+            id: "test-msg-1",
+            createdAt: new Date(),
           },
         ],
       });
@@ -152,10 +156,12 @@ describe("Agent", () => {
       const outputState = await app.invoke({
         messages: [
           {
+            type: "human",
             data: {
               message: "echo the word 'hello'",
             },
-            type: "human",
+            id: "test-msg-1",
+            createdAt: new Date(),
           },
         ],
       });
@@ -209,6 +215,8 @@ describe("Agent", () => {
           data: {
             message: "Return the word 'hello'",
           },
+          id: "test-msg-1",
+          createdAt: new Date(),
         },
       ];
 
@@ -239,6 +247,8 @@ describe("Agent", () => {
           data: {
             message: "echo the word 'hello' and then the word 'goodbye'",
           },
+          id: "test-msg-1",
+          createdAt: new Date(),
         },
         {
           type: "agent",
@@ -254,6 +264,8 @@ describe("Agent", () => {
               },
             ],
           },
+          id: "test-msg-2",
+          createdAt: new Date(),
         },
         // Something caused the workflow to interrupt (request approval / host crashed, etc)
       ];
@@ -302,6 +314,8 @@ describe("Agent", () => {
           data: {
             message: "Echo the word 'hello' and then 'goodbye'",
           },
+          id: "test-msg-1",
+          createdAt: new Date(),
         },
         {
           type: "agent",
@@ -315,10 +329,14 @@ describe("Agent", () => {
               },
             ],
           },
+          id: "test-msg-2",
+          createdAt: new Date(),
         },
         {
           type: "invocation-result",
           data: { id: "123", result: { output: "hello" } },
+          id: "test-msg-3",
+          createdAt: new Date(),
         },
         {
           type: "agent",
@@ -332,6 +350,8 @@ describe("Agent", () => {
               },
             ],
           },
+          id: "test-msg-4",
+          createdAt: new Date(),
         },
         // Something caused the workflow to interrupt (request approval / host crashed, etc)
       ];
@@ -432,10 +452,12 @@ describe("Agent", () => {
       const outputState = await app.invoke({
         messages: [
           {
+            type: "human",
             data: {
               message: "What is the special word?",
             },
-            type: "human",
+            id: "test-msg-1",
+            createdAt: new Date(),
           },
         ],
       });


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Added missing metadata (`id` and `createdAt`) to test messages in `agent.ai.test.ts`.

- Improved test message structure for better consistency and traceability.

- Enhanced test coverage by ensuring all test messages include metadata.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>agent.ai.test.ts</strong><dd><code>Add metadata fields to test messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

control-plane/src/modules/workflows/agent/agent.ai.test.ts

<li>Added <code>id</code> and <code>createdAt</code> fields to test messages.<br> <li> Ensured all test cases include consistent metadata for messages.<br> <li> Improved test message structure for better debugging and traceability.


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/463/files#diff-92d0bd743884a650d83217310bddaf7ab39b837586816830c277fa697ae2efc7">+26/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information