### PR TITLE
feat: Rename workflow_metadata -> run_tags

### DIFF
--- a/app/client/contract.ts
+++ b/app/client/contract.ts
@@ -569,10 +569,14 @@ export const definition = {
         })
         .optional()
         .describe("Mechanism for receiving notifications when the run status changes"),
+      tags: z
+        .record(z.string())
+        .optional()
+        .describe("Run tags which can be used to filter runs"),
       metadata: z
         .record(z.string())
         .optional()
-        .describe("Run metadata which can be used to filter runs"),
+        .describe("DEPRECATED"),
       test: z
         .object({
           enabled: z.boolean().default(false),
@@ -700,7 +704,8 @@ export const definition = {
         .transform(value => value === "true")
         .optional(),
       limit: z.coerce.number().min(10).max(50).default(50),
-      metadata: z.string().optional().describe("Filter runs by a metadata value (value:key)"),
+      tags: z.string().optional().describe("Filter runs by a tag value (value:key)"),
+      metadata: z.string().optional().describe("DEPRECATED"),
       agentId: z.string().optional(),
     }),
     responses: {
@@ -738,7 +743,7 @@ export const definition = {
         context: z.any().nullable(),
         authContext: z.any().nullable(),
         result: anyObject.nullable(),
-        metadata: z.record(z.string()).nullable(),
+        tags: z.record(z.string()).nullable(),
         attachedFunctions: z.array(z.string()).nullable(),
       }),
       401: z.undefined(),
@@ -1031,6 +1036,7 @@ export const definition = {
       404: z.undefined(),
     },
   },
+  // TODO: Remove
   upsertFunctionMetadata: {
     method: "PUT",
     path: "/clusters/:clusterId/:service/:function/metadata",
@@ -1050,6 +1056,7 @@ export const definition = {
       401: z.undefined(),
     },
   },
+  // TODO: Remove
   getFunctionMetadata: {
     method: "GET",
     path: "/clusters/:clusterId/:service/:function/metadata",
@@ -1069,6 +1076,7 @@ export const definition = {
       404: z.object({ message: z.string() }),
     },
   },
+  // TOOD: Remove
   deleteFunctionMetadata: {
     method: "DELETE",
     path: "/clusters/:clusterId/:service/:function/metadata",

--- a/app/components/workflow.tsx
+++ b/app/components/workflow.tsx
@@ -24,7 +24,6 @@ import { DebugEvent } from "./debug-event";
 import { Skeleton } from "@/components/ui/skeleton";
 import { toast } from "react-hot-toast";
 import { Blob } from "./chat/blob";
-import { Strait } from "next/font/google";
 
 const messageSkeleton = (
   <div className="flex flex-col items-start space-y-4 p-4" key="skeleton-0">
@@ -381,11 +380,11 @@ export function Run({ clusterId, runId }: { clusterId: string; runId: string }) 
                 </div>
               </div>
 
-              {run.metadata && Object.keys(run.metadata).length > 0 && (
+              {run.tags && Object.keys(run.tags).length > 0 && (
                 <div className="flex flex-col space-y-1">
-                  <span className="text-xs font-medium text-gray-500">Metadata</span>
+                  <span className="text-xs font-medium text-gray-500">Tags</span>
                   <div className="flex flex-wrap gap-1">
-                    {Object.entries(run.metadata).map(([key, value]) => (
+                    {Object.entries(run.tags).map(([key, value]) => (
                       <div
                         key={key}
                         className="bg-gray-100 px-2 py-0.5 rounded text-xs"

--- a/control-plane/src/modules/contract.ts
+++ b/control-plane/src/modules/contract.ts
@@ -569,10 +569,14 @@ export const definition = {
         })
         .optional()
         .describe("Mechanism for receiving notifications when the run status changes"),
+      tags: z
+        .record(z.string())
+        .optional()
+        .describe("Run tags which can be used to filter runs"),
       metadata: z
         .record(z.string())
         .optional()
-        .describe("Run metadata which can be used to filter runs"),
+        .describe("DEPRECATED"),
       test: z
         .object({
           enabled: z.boolean().default(false),
@@ -700,7 +704,8 @@ export const definition = {
         .transform(value => value === "true")
         .optional(),
       limit: z.coerce.number().min(10).max(50).default(50),
-      metadata: z.string().optional().describe("Filter runs by a metadata value (value:key)"),
+      tags: z.string().optional().describe("Filter runs by a tag value (value:key)"),
+      metadata: z.string().optional().describe("DEPRECATED"),
       agentId: z.string().optional(),
     }),
     responses: {
@@ -738,7 +743,7 @@ export const definition = {
         context: z.any().nullable(),
         authContext: z.any().nullable(),
         result: anyObject.nullable(),
-        metadata: z.record(z.string()).nullable(),
+        tags: z.record(z.string()).nullable(),
         attachedFunctions: z.array(z.string()).nullable(),
       }),
       401: z.undefined(),
@@ -1031,6 +1036,7 @@ export const definition = {
       404: z.undefined(),
     },
   },
+  // TODO: Remove
   upsertFunctionMetadata: {
     method: "PUT",
     path: "/clusters/:clusterId/:service/:function/metadata",
@@ -1050,6 +1056,7 @@ export const definition = {
       401: z.undefined(),
     },
   },
+  // TODO: Remove
   getFunctionMetadata: {
     method: "GET",
     path: "/clusters/:clusterId/:service/:function/metadata",
@@ -1069,6 +1076,7 @@ export const definition = {
       404: z.object({ message: z.string() }),
     },
   },
+  // TOOD: Remove
   deleteFunctionMetadata: {
     method: "DELETE",
     path: "/clusters/:clusterId/:service/:function/metadata",

--- a/control-plane/src/modules/data.ts
+++ b/control-plane/src/modules/data.ts
@@ -226,7 +226,8 @@ export const integrations = pgTable(
   })
 );
 
-export const workflowMetadata = pgTable(
+export const runTags = pgTable(
+  // TODO: Rename to `run_tags`
   "workflow_metadata",
   {
     cluster_id: varchar("cluster_id").notNull(),
@@ -247,6 +248,7 @@ export const workflowMetadata = pgTable(
   })
 );
 
+// TODO: Rename to Runs
 export const workflows = pgTable(
   "workflows",
   {
@@ -558,7 +560,7 @@ export const db = drizzle(pool, {
   schema: {
     workflows,
     toolMetadata,
-    promptTemplates: agents,
+    agents,
     events,
   },
 });

--- a/control-plane/src/modules/email/index.ts
+++ b/control-plane/src/modules/email/index.ts
@@ -64,7 +64,7 @@ export const stop = async () => {
 
 export const handleNewRunMessage = async ({
   message,
-  runMetadata,
+  tags,
 }: {
   message: {
     id: string;
@@ -73,16 +73,16 @@ export const handleNewRunMessage = async ({
     type: InferSelectModel<typeof workflowMessages>["type"];
     data: InferSelectModel<typeof workflowMessages>["data"];
   };
-  runMetadata?: Record<string, string>;
+  tags?: Record<string, string>;
 }) => {
   if (message.type !== "agent") {
     return;
   }
 
   if (
-    !runMetadata?.[EMAIL_INIT_MESSAGE_ID_META_KEY] ||
-    !runMetadata?.[EMAIL_SUBJECT_META_KEY] ||
-    !runMetadata?.[EMAIL_SOURCE_META_KEY]
+    !tags?.[EMAIL_INIT_MESSAGE_ID_META_KEY] ||
+    !tags?.[EMAIL_SUBJECT_META_KEY] ||
+    !tags?.[EMAIL_SOURCE_META_KEY]
   ) {
     return;
   }
@@ -93,12 +93,12 @@ export const handleNewRunMessage = async ({
     const result = await ses.sendEmail({
       Source: `"Inferable" <${message.clusterId}@${env.INFERABLE_EMAIL_DOMAIN}>`,
       Destination: {
-        ToAddresses: [runMetadata[EMAIL_SOURCE_META_KEY]],
+        ToAddresses: [tags[EMAIL_SOURCE_META_KEY]],
       },
       Message: {
         Subject: {
           Charset: "UTF-8",
-          Data: `Re: ${runMetadata[EMAIL_SUBJECT_META_KEY]}`,
+          Data: `Re: ${tags[EMAIL_SUBJECT_META_KEY]}`,
         },
         Body: {
           Text: {
@@ -309,7 +309,7 @@ const handleNewChain = async ({
   await createRunWithMessage({
     userId,
     clusterId,
-    metadata: {
+    tags: {
       [EMAIL_INIT_MESSAGE_ID_META_KEY]: messageId,
       [EMAIL_SUBJECT_META_KEY]: subject,
       [EMAIL_SOURCE_META_KEY]: source,

--- a/control-plane/src/modules/workflows/agent/run.ts
+++ b/control-plane/src/modules/workflows/agent/run.ts
@@ -33,7 +33,7 @@ import { buildMockFunctionTool } from "./tools/mock-function";
 /**
  * Run a workflow from the most recent saved state
  **/
-export const processRun = async (run: Run, metadata?: Record<string, string>) => {
+export const processRun = async (run: Run, tags?: Record<string, string>) => {
   logger.info("Running workflow");
 
   // Parallelize fetching additional context and service definitions
@@ -158,7 +158,7 @@ export const processRun = async (run: Run, metadata?: Record<string, string>) =>
       for (const message of state.messages.filter(m => !m.persisted)) {
         await Promise.all([
           insertRunMessage(message),
-          notifyNewMessage({ message, runMetadata: metadata }),
+          notifyNewMessage({ message, tags }),
         ]);
         message.persisted = true;
       }

--- a/control-plane/src/modules/workflows/tags.test.ts
+++ b/control-plane/src/modules/workflows/tags.test.ts
@@ -1,5 +1,5 @@
 import { createOwner } from "../test/util";
-import { getRunsByMetadata } from "./metadata";
+import { getRunsByTag } from "./tags";
 import { createRun } from "./workflows";
 
 describe("getWorkflowsByMetadata", () => {
@@ -12,19 +12,19 @@ describe("getWorkflowsByMetadata", () => {
   it("should return workflows with matching metadata", async () => {
     const workflow = await createRun({
       clusterId: owner.clusterId,
-      metadata: {
+      tags: {
         foo: "bar",
       },
     });
 
     await createRun({
       clusterId: owner.clusterId,
-      metadata: {
+      tags: {
         foo: "baz",
       },
     });
 
-    const result = await getRunsByMetadata({
+    const result = await getRunsByTag({
       clusterId: owner.clusterId,
       key: "foo",
       value: "bar",

--- a/control-plane/src/modules/workflows/tags.ts
+++ b/control-plane/src/modules/workflows/tags.ts
@@ -1,7 +1,7 @@
 import { and, eq, desc } from "drizzle-orm";
-import { db, workflowMetadata, workflows } from "../data";
+import { db, runTags, workflows } from "../data";
 
-export const getRunsByMetadata = async ({
+export const getRunsByTag = async ({
   clusterId,
   key,
   value,
@@ -31,42 +31,42 @@ export const getRunsByMetadata = async ({
       agentVersion: workflows.agent_version,
       feedbackScore: workflows.feedback_score,
     })
-    .from(workflowMetadata)
+    .from(runTags)
     .where(
       and(
-        eq(workflowMetadata.cluster_id, clusterId),
-        eq(workflowMetadata.key, key),
-        eq(workflowMetadata.value, value),
+        eq(runTags.cluster_id, clusterId),
+        eq(runTags.key, key),
+        eq(runTags.value, value),
         ...(agentId ? [eq(workflows.agent_id, agentId)] : []),
         ...(userId ? [eq(workflows.user_id, userId)] : []),
       ),
     )
-    .rightJoin(workflows, eq(workflowMetadata.workflow_id, workflows.id))
+    .rightJoin(workflows, eq(runTags.workflow_id, workflows.id))
     .orderBy(desc(workflows.created_at))
     .limit(limit);
 };
 
-export const getRunMetadata = async ({
+export const getRunTags = async ({
   clusterId,
   runId,
 }: {
   clusterId: string;
   runId: string;
 }) => {
-  const metadata = await db
+  const tags = await db
     .select({
-      key: workflowMetadata.key,
-      value: workflowMetadata.value,
+      key: runTags.key,
+      value: runTags.value,
     })
-    .from(workflowMetadata)
+    .from(runTags)
     .where(
       and(
-        eq(workflowMetadata.cluster_id, clusterId),
-        eq(workflowMetadata.workflow_id, runId),
+        eq(runTags.cluster_id, clusterId),
+        eq(runTags.workflow_id, runId),
       ),
     );
 
-  return metadata.reduce(
+  return tags.reduce(
     (acc, { key, value }) => {
       acc[key] = value;
       return acc;

--- a/sdk-node/src/contract.ts
+++ b/sdk-node/src/contract.ts
@@ -569,10 +569,14 @@ export const definition = {
         })
         .optional()
         .describe("Mechanism for receiving notifications when the run status changes"),
+      tags: z
+        .record(z.string())
+        .optional()
+        .describe("Run tags which can be used to filter runs"),
       metadata: z
         .record(z.string())
         .optional()
-        .describe("Run metadata which can be used to filter runs"),
+        .describe("DEPRECATED"),
       test: z
         .object({
           enabled: z.boolean().default(false),
@@ -700,7 +704,8 @@ export const definition = {
         .transform(value => value === "true")
         .optional(),
       limit: z.coerce.number().min(10).max(50).default(50),
-      metadata: z.string().optional().describe("Filter runs by a metadata value (value:key)"),
+      tags: z.string().optional().describe("Filter runs by a tag value (value:key)"),
+      metadata: z.string().optional().describe("DEPRECATED"),
       agentId: z.string().optional(),
     }),
     responses: {
@@ -738,7 +743,7 @@ export const definition = {
         context: z.any().nullable(),
         authContext: z.any().nullable(),
         result: anyObject.nullable(),
-        metadata: z.record(z.string()).nullable(),
+        tags: z.record(z.string()).nullable(),
         attachedFunctions: z.array(z.string()).nullable(),
       }),
       401: z.undefined(),
@@ -1031,6 +1036,7 @@ export const definition = {
       404: z.undefined(),
     },
   },
+  // TODO: Remove
   upsertFunctionMetadata: {
     method: "PUT",
     path: "/clusters/:clusterId/:service/:function/metadata",
@@ -1050,6 +1056,7 @@ export const definition = {
       401: z.undefined(),
     },
   },
+  // TODO: Remove
   getFunctionMetadata: {
     method: "GET",
     path: "/clusters/:clusterId/:service/:function/metadata",
@@ -1069,6 +1076,7 @@ export const definition = {
       404: z.object({ message: z.string() }),
     },
   },
+  // TOOD: Remove
   deleteFunctionMetadata: {
     method: "DELETE",
     path: "/clusters/:clusterId/:service/:function/metadata",

--- a/sdk-node/src/types.ts
+++ b/sdk-node/src/types.ts
@@ -40,7 +40,7 @@ export const onStatusChangeInput = z.object({
   status: z.enum(["pending", "running", "paused", "done", "failed"]),
   result: z.object({}).passthrough().nullable().optional(),
   summary: z.string().nullable().optional(),
-  metadata: z.record(z.string()).nullable().optional(),
+  tags: z.record(z.string()).nullable().optional(),
 });
 
 /**


### PR DESCRIPTION
### **User description**
Renames A Run's "metadata" to "tags" to better represent the intended usage.
For now `tags` and `metadata` will be accepted. This will be cleaned up in a future PR.

I will apply the DB table / index changes in a seperate PR.
___

### **PR Type**
Enhancement, Bug fix, Dependencies


___

### **Description**
- Renamed `workflow_metadata` to `run_tags` for improved clarity.

- Deprecated `metadata` in favor of `tags` across the codebase.

- Updated database schema and migrations to reflect the renaming.

- Upgraded `drizzle-kit` and `drizzle-orm` dependencies to resolve issues.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td><strong>contract.ts</strong><dd><code>Added `tags` and deprecated `metadata` in API definitions.</code></dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/473/files#diff-b5950839f91929a72fdc1a19dbd99f3c7db3032893deb18743fc93deff2e34bc">+11/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>data.ts</strong><dd><code>Renamed `workflow_metadata` table to `run_tags`.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/473/files#diff-389a480d000c3f91c0ca76b0cacd863c9db8ded03e464a9df80b7e905d233a05">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Replaced `metadata` with `tags` in email handling logic.</code>&nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/473/files#diff-6338c186d160099dfc1a5bbf40f75e08318c49dfce050119dc3ce610377c6dcf">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Updated Slack integration to use `tags` instead of `metadata`.</code></dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/473/files#diff-371db4e2ab9c97fb66d167e085aad6f537472811427c427967ef527f85dfa483">+13/-13</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>run.ts</strong><dd><code>Replaced `metadata` with `tags` in workflow processing.</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/473/files#diff-a62f5f3174aae975a27f181aae16b24c00c49fb698770b073ac7f530003ae172">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>notify.ts</strong><dd><code>Updated notification logic to use `tags` instead of `metadata`.</code></dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/473/files#diff-8d433b806d2d1d7a8a03e411415abc4397320e5c0314d773be2ac8b18bea6356">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>queues.ts</strong><dd><code>Replaced `metadata` with `tags` in queue processing.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/473/files#diff-9fa7012c847fc1dfd76fe058d852485f077b5b6066e7abed1b38782c2a534b27">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>router.ts</strong><dd><code>Deprecated `metadata` in API routes and replaced with `tags`.</code></dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/473/files#diff-ec9592ce01e121f7ef9dfb72f9726dcb795c07245e6ad808a8621b96ae8667bc">+23/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tags.ts</strong><dd><code>Renamed and updated functions to use `tags`.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/473/files#diff-1cba6dd03789ed67916580a39ff44a12cc8cfa4e4b3601eb7d9b0c0efb9a594f">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>workflows.ts</strong><dd><code>Replaced `metadata` with `tags` in workflow logic.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/473/files#diff-17e8112ac05d30dbcbdf5b549c08800a1a3f5dc79df9500931b34e7ac8c0dc25">+12/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>contract.ts</strong><dd><code>Added `tags` and deprecated `metadata` in SDK definitions.</code></dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/473/files#diff-471c07a721c8f0439fb7b473243c039c94a26a554588aced362d87b771fd9cdd">+11/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>tags.test.ts</strong><dd><code>Updated tests to reflect `tags` usage instead of `metadata`.</code></dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/473/files#diff-ec81cff4f98a9fdc72dbfcbd7c90b558db55fbb2f2632890c0d0e5d504f02a2e">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>0205_rare_viper.sql</strong><dd><code>Database migration to rename `workflow_metadata` to `run_tags`.</code></dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/473/files#diff-0214942ba40d4535f9cec7986de13a89e7255c77a50d501b6744282df5efbf29">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>0205_snapshot.json</strong><dd><code>Updated database snapshot to reflect `run_tags` changes.</code>&nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/473/files#diff-93c94eaf1a52fa7e9b8920413ba222306aece7822ed776aefd36b54aa82eb1a3">+1697/-0</a></td>

</tr>

<tr>
  <td><strong>_journal.json</strong><dd><code>Added migration entry for `run_tags` renaming.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/473/files#diff-aa9deb64cfd6f26fa919729d5aa2e5efffe5c8d2a170cd5e05bad1e32e242649">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>package-lock.json</strong><dd><code>Updated `drizzle-kit` and `drizzle-orm` dependencies.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/473/files#diff-73ae9fcf819087c517bf32eea8525e1299dd468e02d60935d250ac2754011c57">+23/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>package.json</strong><dd><code>Updated `drizzle-kit` and `drizzle-orm` dependencies.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/473/files#diff-070cd4aad1ab03316d3296db441613c1bbf7a8b657272fbb00d52174e7ce048b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information