### PR TITLE
fix: Correct usage of unifiedMessageSchema

### DIFF
--- a/control-plane/src/modules/contract.ts
+++ b/control-plane/src/modules/contract.ts
@@ -144,53 +144,53 @@ const agentDataSchema = z
   })
   .strict();
 
-const peripheralMessageDataSchema = z.object({
+const peripheralMessageSchema = z.object({
   id: z.string(),
   createdAt: z.date().optional(),
   pending: z.boolean().optional(),
   metadata: z.record(z.unknown()).optional().nullable(),
 });
 
-export const unifiedMessageDataSchema = z.discriminatedUnion("type", [
+export const unifiedMessageSchema = z.discriminatedUnion("type", [
   z
     .object({
       type: z.literal("agent"),
       data: agentDataSchema,
     })
-    .merge(peripheralMessageDataSchema),
+    .merge(peripheralMessageSchema),
   z
     .object({
       type: z.literal("invocation-result"),
       data: resultDataSchema,
     })
-    .merge(peripheralMessageDataSchema),
+    .merge(peripheralMessageSchema),
   z
     .object({
       type: z.literal("human"),
       data: genericMessageDataSchema,
     })
-    .merge(peripheralMessageDataSchema),
+    .merge(peripheralMessageSchema),
   z
     .object({
       type: z.literal("template"),
       data: genericMessageDataSchema,
     })
-    .merge(peripheralMessageDataSchema),
+    .merge(peripheralMessageSchema),
   z
     .object({
       type: z.literal("supervisor"),
       data: genericMessageDataSchema,
     })
-    .merge(peripheralMessageDataSchema),
+    .merge(peripheralMessageSchema),
   z
     .object({
       type: z.literal("agent-invalid"),
       data: genericMessageDataSchema,
     })
-    .merge(peripheralMessageDataSchema),
+    .merge(peripheralMessageSchema),
 ]);
 
-export type UnifiedMessage = z.infer<typeof unifiedMessageDataSchema>;
+export type UnifiedMessage = z.infer<typeof unifiedMessageSchema>;
 
 export type MessageTypes =
   | "agent"
@@ -682,7 +682,7 @@ export const definition = {
       limit: z.coerce.number().min(10).max(50).default(50),
     }),
     responses: {
-      200: z.array(unifiedMessageDataSchema),
+      200: z.array(unifiedMessageSchema),
       401: z.undefined(),
     },
   },
@@ -976,7 +976,7 @@ export const definition = {
     responses: {
       404: z.undefined(),
       200: z.object({
-        messages: z.array(unifiedMessageDataSchema),
+        messages: z.array(unifiedMessageSchema),
         activity: z.array(
           z.object({
             id: z.string(),

--- a/control-plane/src/modules/email/index.ts
+++ b/control-plane/src/modules/email/index.ts
@@ -14,7 +14,7 @@ import { workflowMessages } from "../data";
 import { ses } from "../ses";
 import { getMessageByReference, updateMessageReference } from "../workflows/workflow-messages";
 import { ulid } from "ulid";
-import { unifiedMessageDataSchema } from "../contract";
+import { unifiedMessageSchema } from "../contract";
 
 const EMAIL_INIT_MESSAGE_ID_META_KEY = "emailInitMessageId";
 const EMAIL_SUBJECT_META_KEY = "emailSubject";
@@ -87,7 +87,7 @@ export const handleNewRunMessage = async ({
     return;
   }
 
-  const messageData = unifiedMessageDataSchema.parse(message.data).data;
+  const messageData = unifiedMessageSchema.parse(message).data;
 
   if ("message" in messageData && messageData.message) {
     const result = await ses.sendEmail({

--- a/control-plane/src/modules/integrations/slack/index.ts
+++ b/control-plane/src/modules/integrations/slack/index.ts
@@ -15,7 +15,7 @@ import { integrationSchema } from "../schema";
 import { z } from "zod";
 import { getUserForCluster } from "../../clerk";
 import { submitApproval } from "../../jobs/jobs";
-import { unifiedMessageDataSchema } from "../../contract";
+import { unifiedMessageSchema } from "../../contract";
 
 const THREAD_META_KEY = "slackThreadTs";
 const CHANNEL_META_KEY = "slackChannel";
@@ -123,7 +123,7 @@ export const handleNewRunMessage = async ({
 
   const client = new webApi.WebClient(token);
 
-  const messageData = unifiedMessageDataSchema.parse(message.data).data;
+  const messageData = unifiedMessageSchema.parse(message).data;
 
   if ("message" in messageData && messageData.message) {
     client?.chat.postMessage({
@@ -575,7 +575,9 @@ const authenticateUser = async (
     throw new AuthenticationError("Could not authenticate Slack user");
   }
 
-  return clerkUser;
+  return {
+    userId: `clerk:${clerkUser.id}`,
+  };
 };
 
 const handleCallApprovalAction = async ({

--- a/control-plane/src/modules/workflows/workflow-messages.ts
+++ b/control-plane/src/modules/workflows/workflow-messages.ts
@@ -2,13 +2,13 @@ import Anthropic from "@anthropic-ai/sdk";
 import { and, desc, eq, gt, InferSelectModel, ne, sql } from "drizzle-orm";
 import { ulid } from "ulid";
 import { z } from "zod";
-import { UnifiedMessage, unifiedMessageDataSchema } from "../contract";
+import { UnifiedMessage, unifiedMessageSchema } from "../contract";
 import { db, RunMessageMetadata, workflowMessages } from "../data";
 import { events } from "../observability/events";
 import { resumeRun } from "./workflows";
 import { logger } from "../observability/logger";
 
-export type TypedMessage = z.infer<typeof unifiedMessageDataSchema>;
+export type TypedMessage = z.infer<typeof unifiedMessageSchema>;
 
 /**
  * A structured response from the agent.
@@ -28,7 +28,7 @@ export type GenericMessage = Extract<
   { type: "human" | "template" | "supervisor" | "agent-invalid" }
 >;
 
-export type RunMessage = z.infer<typeof unifiedMessageDataSchema>;
+export type RunMessage = z.infer<typeof unifiedMessageSchema>;
 
 export const insertRunMessage = async ({
   clusterId,
@@ -158,7 +158,7 @@ export const getRunMessagesForDisplay = async ({
       return message;
     })
     .map(message => {
-      const { success, data, error } = unifiedMessageDataSchema.safeParse(message);
+      const { success, data, error } = unifiedMessageSchema.safeParse(message);
 
       if (!success) {
         logger.error("Invalid message data. Returning supervisor message", {
@@ -268,7 +268,7 @@ export const getWorkflowMessages = async ({
     .map(message => {
       return {
         ...message,
-        ...unifiedMessageDataSchema.parse(message),
+        ...unifiedMessageSchema.parse(message),
       };
     });
 };
@@ -364,7 +364,7 @@ export function hasInvocations(message: AgentMessage): boolean {
 export function assertMessageOfType<
   T extends "agent" | "invocation-result" | "human" | "template" | "supervisor" | "agent-invalid",
 >(type: T, message: unknown) {
-  const result = unifiedMessageDataSchema.safeParse(message);
+  const result = unifiedMessageSchema.safeParse(message);
 
   if (!result.success) {
     throw new Error("Invalid message data");


### PR DESCRIPTION
### **User description**
- Correct `unifiedMessageSchema` usage in Slack and Email modules (This was parsing the `data` key, the schema is actually for the whole object).
- Rename `unifiedMessageSchemaData` -> `unifiedMessageSchema` to avoid the same confusion


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Corrected the usage of `unifiedMessageSchema` across modules.

- Renamed `unifiedMessageDataSchema` to `unifiedMessageSchema` for clarity.

- Updated schema parsing logic to fix data handling issues.

- Adjusted related type definitions and function implementations.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>contract.ts</strong><dd><code>Refactored and fixed `unifiedMessageSchema` in contract module</code></dd></summary>
<hr>

control-plane/src/modules/contract.ts

<li>Renamed <code>unifiedMessageDataSchema</code> to <code>unifiedMessageSchema</code>.<br> <li> Updated schema merging logic to use <code>peripheralMessageSchema</code>.<br> <li> Adjusted type definitions to align with the new schema name.<br> <li> Fixed API response schema references to use <code>unifiedMessageSchema</code>.


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/479/files#diff-b5950839f91929a72fdc1a19dbd99f3c7db3032893deb18743fc93deff2e34bc">+11/-11</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>workflow-messages.ts</strong><dd><code>Refactored workflow messages to use `unifiedMessageSchema`</code></dd></summary>
<hr>

control-plane/src/modules/workflows/workflow-messages.ts

<li>Replaced <code>unifiedMessageDataSchema</code> with <code>unifiedMessageSchema</code>.<br> <li> Updated type definitions and parsing logic for workflow messages.<br> <li> Fixed schema parsing in message retrieval functions.


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/479/files#diff-d30d2ee300da8f01f2a2a379b3556e1c28aa845d17d034477a2fde49341278c3">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Updated email module to use `unifiedMessageSchema`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

control-plane/src/modules/email/index.ts

<li>Replaced <code>unifiedMessageDataSchema</code> with <code>unifiedMessageSchema</code>.<br> <li> Fixed schema parsing logic for email message handling.


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/479/files#diff-6338c186d160099dfc1a5bbf40f75e08318c49dfce050119dc3ce610377c6dcf">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Updated Slack integration to use `unifiedMessageSchema`</code>&nbsp; &nbsp; </dd></summary>
<hr>

control-plane/src/modules/integrations/slack/index.ts

<li>Replaced <code>unifiedMessageDataSchema</code> with <code>unifiedMessageSchema</code>.<br> <li> Fixed schema parsing logic for Slack message handling.<br> <li> Adjusted user authentication return structure.


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/479/files#diff-371db4e2ab9c97fb66d167e085aad6f537472811427c427967ef527f85dfa483">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information