### PR TITLE
fix: Corerct Clerk ID formatting in slack / email modules

### DIFF
--- a/control-plane/src/modules/email/index.ts
+++ b/control-plane/src/modules/email/index.ts
@@ -240,7 +240,7 @@ async function handleEmailIngestion(raw: unknown) {
     }
 
     return await handleExistingChain({
-      userId: user.id,
+      userId: user.userId,
       body: message.body,
       clusterId: message.clusterId,
       messageId: message.messageId,
@@ -249,7 +249,7 @@ async function handleEmailIngestion(raw: unknown) {
   }
 
   await handleNewChain({
-    userId: user.id,
+    userId: user.userId,
     body: message.body,
     clusterId: message.clusterId,
     messageId: message.messageId,
@@ -287,7 +287,9 @@ const authenticateUser = async (emailAddress: string, clusterId: string) => {
     throw new AuthenticationError("Could not authenticate Email sender");
   }
 
-  return clerkUser;
+  return {
+    userId: `clerk:${clerkUser.id}`,
+  };
 };
 
 const handleNewChain = async ({

--- a/control-plane/src/modules/integrations/slack/index.ts
+++ b/control-plane/src/modules/integrations/slack/index.ts
@@ -319,14 +319,14 @@ export const start = async (fastify: FastifyInstance) => {
 
       if (hasThread(event)) {
         await handleExistingThread({
-          userId: user?.id,
+          userId: user?.userId,
           event,
           client,
           clusterId: integration.cluster_id,
         });
       } else {
         await handleNewThread({
-          userId: user?.id,
+          userId: user?.userId,
           event,
           client,
           clusterId: integration.cluster_id,


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Corrected `userId` assignment in email module functions.

- Fixed `userId` assignment in Slack integration functions.

- Standardized `userId` format to include `clerk:` prefix.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Fix userId handling in email module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

control-plane/src/modules/email/index.ts

<li>Replaced <code>user.id</code> with <code>user.userId</code> in function calls.<br> <li> Standardized <code>userId</code> format to include <code>clerk:</code> prefix.<br> <li> Adjusted return structure of <code>authenticateUser</code> function.


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/481/files#diff-6338c186d160099dfc1a5bbf40f75e08318c49dfce050119dc3ce610377c6dcf">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Fix userId handling in Slack module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

control-plane/src/modules/integrations/slack/index.ts

<li>Replaced <code>user?.id</code> with <code>user?.userId</code> in function calls.<br> <li> Ensured consistent <code>userId</code> usage in Slack integration.


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/481/files#diff-371db4e2ab9c97fb66d167e085aad6f537472811427c427967ef527f85dfa483">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information