### PR TITLE
fix: Fix agent tests after workflow rename

### DIFF
--- a/control-plane/package.json
+++ b/control-plane/package.json
@@ -5,7 +5,6 @@
   "description": "Inferable control plane is the backend for the Inferable platform.",
   "scripts": {
     "test": "tsx -r dotenv/config src/utilities/run-migrate.ts && jest src --setupFiles dotenv/config --forceExit --testPathIgnorePatterns=.*\\.ai\\.test\\.ts$ --testMatch='**/*.test.ts'",
-    "test:ai:eval": "tsx -r dotenv/config src/modules/workflows/agent/evaluation",
     "test:ai": "jest src --testMatch='**/*.ai.test.ts' --setupFiles dotenv/config --forceExit",
     "test:dev": "jest --watch  src --setupFiles dotenv/config --forceExit --onlyChanged --testMatch='**/*.test.ts'",
     "dev": "tsx --watch -r dotenv/config src/index.ts",

--- a/control-plane/src/modules/data.ts
+++ b/control-plane/src/modules/data.ts
@@ -248,8 +248,8 @@ export const runTags = pgTable(
   })
 );
 
-// TODO: Rename to Runs
 export const runs = pgTable(
+  // TODO: Rename to runs
   "workflows",
   {
     id: varchar("id", { length: 1024 }).notNull(),
@@ -313,6 +313,7 @@ export type RunMessageMetadata = {
 };
 
 export const runMessages = pgTable(
+  // TODO: Rename to `run_messages`
   "workflow_messages",
   {
     id: varchar("id", { length: 1024 }).notNull(),
@@ -558,7 +559,7 @@ export const analyticsSnapshots = pgTable(
 
 export const db = drizzle(pool, {
   schema: {
-    workflows: runs,
+    runs,
     toolMetadata,
     agents,
     events,

--- a/control-plane/src/modules/runs/agent/agent.ai.test.ts
+++ b/control-plane/src/modules/runs/agent/agent.ai.test.ts
@@ -14,7 +14,7 @@ describe("Agent", () => {
 
   const toolCallback = jest.fn();
 
-  const workflow = {
+  const run = {
     id: "test",
     clusterId: "test",
   };
@@ -53,7 +53,7 @@ describe("Agent", () => {
 
     it("should call a tool and exit", async () => {
       const app = await createRunGraph({
-        run: workflow,
+        run: run,
         findRelevantTools: async () => tools,
         getTool: async () => tools[0],
         postStepSave: async () => {},
@@ -82,8 +82,8 @@ describe("Agent", () => {
 
       expect(toolCallback).toHaveBeenCalledWith("hello");
 
-      expect(outputState.workflow).toEqual({
-        ...workflow,
+      expect(outputState.run).toEqual({
+        ...run,
         checkpointData: undefined,
       });
 
@@ -97,7 +97,7 @@ describe("Agent", () => {
 
     it("should call a tool multiple times and exit", async () => {
       const app = await createRunGraph({
-        run: workflow,
+        run: run,
         findRelevantTools: async () => tools,
         getTool: async () => tools[0],
         postStepSave: async () => {},
@@ -127,7 +127,7 @@ describe("Agent", () => {
       expect(toolCallback).toHaveBeenNthCalledWith(1, "hello");
       expect(toolCallback).toHaveBeenNthCalledWith(2, "goodbye");
 
-      expect(outputState.workflow).toEqual(workflow);
+      expect(outputState.run).toEqual(run);
 
       expect(outputState.messages).toHaveLength(5);
       expect(outputState.messages[0]).toHaveProperty("type", "human");
@@ -139,7 +139,7 @@ describe("Agent", () => {
 
     it("should present tool failure to agent", async () => {
       const app = await createRunGraph({
-        run: workflow,
+        run: run,
         findRelevantTools: async () => tools,
         getTool: async () => tools[0],
         postStepSave: async () => {},
@@ -168,7 +168,7 @@ describe("Agent", () => {
 
       expect(toolCallback).toHaveBeenCalledWith("hello");
 
-      expect(outputState.workflow).toEqual(workflow);
+      expect(outputState.run).toEqual(run);
 
       expect(outputState.messages).toHaveLength(4);
       expect(outputState.messages[0]).toHaveProperty("type", "human");
@@ -194,7 +194,7 @@ describe("Agent", () => {
     it("should result result schema", async () => {
       const app = await createRunGraph({
         run: {
-          ...workflow,
+          ...run,
           resultSchema: {
             type: "object",
             properties: {
@@ -221,7 +221,7 @@ describe("Agent", () => {
       ];
 
       const outputState = await app.invoke({
-        workflow,
+        run,
         messages,
       });
 
@@ -240,7 +240,7 @@ describe("Agent", () => {
     jest.setTimeout(120000);
 
     it("should resume with pending tool call", async () => {
-      // Model requested function call, and workflow was interrupted
+      // Model requested function call, and Run was interrupted
       const messages = [
         {
           type: "human",
@@ -267,11 +267,11 @@ describe("Agent", () => {
           id: "test-msg-2",
           createdAt: new Date(),
         },
-        // Something caused the workflow to interrupt (request approval / host crashed, etc)
+        // Something caused the Run to interrupt (request approval / host crashed, etc)
       ];
 
       const app = await createRunGraph({
-        run: workflow,
+        run: run,
         findRelevantTools: async () => tools,
         getTool: async () => tools[0],
         postStepSave: async () => {},
@@ -286,7 +286,7 @@ describe("Agent", () => {
       toolCallback.mockResolvedValue(toolResponse);
 
       const outputState = await app.invoke({
-        workflow,
+        run,
         messages,
       });
 
@@ -294,7 +294,7 @@ describe("Agent", () => {
       expect(toolCallback).toHaveBeenNthCalledWith(1, "hello");
       expect(toolCallback).toHaveBeenNthCalledWith(2, "goodbye");
 
-      expect(outputState.workflow).toEqual(workflow);
+      expect(outputState.run).toEqual(run);
 
       expect(outputState.messages).toHaveLength(6);
 
@@ -307,7 +307,7 @@ describe("Agent", () => {
     });
 
     it("should not recall the same function after resumption", async () => {
-      // Model requested first function call and workflow was interrupted.
+      // Model requested first function call and Run was interrupted.
       const messages = [
         {
           type: "human",
@@ -353,11 +353,11 @@ describe("Agent", () => {
           id: "test-msg-4",
           createdAt: new Date(),
         },
-        // Something caused the workflow to interrupt (request approval / host crashed, etc)
+        // Something caused the Run to interrupt (request approval / host crashed, etc)
       ];
 
       const app = await createRunGraph({
-        run: workflow,
+        run,
         findRelevantTools: async () => tools,
         getTool: async () => tools[0],
         postStepSave: async () => {},
@@ -372,7 +372,7 @@ describe("Agent", () => {
       toolCallback.mockResolvedValue(toolResponse);
 
       const outputState = await app.invoke({
-        workflow,
+        run,
         messages,
       });
 
@@ -380,7 +380,7 @@ describe("Agent", () => {
       expect(toolCallback).toHaveBeenCalledTimes(1);
       expect(toolCallback).toHaveBeenNthCalledWith(1, "goodbye");
 
-      expect(outputState.workflow).toEqual(workflow);
+      expect(outputState.run).toEqual(run);
 
       expect(outputState.messages).toHaveLength(6);
 
@@ -406,7 +406,7 @@ describe("Agent", () => {
 
       const app = await createRunGraph({
         run: {
-          ...workflow,
+          ...run,
           resultSchema: {
             type: "object",
             properties: {

--- a/control-plane/src/modules/runs/agent/agent.ts
+++ b/control-plane/src/modules/runs/agent/agent.ts
@@ -38,7 +38,7 @@ export const createRunGraph = async ({
   getTool: ToolFetcher;
   mockModelResponses?: string[];
 }) => {
-  const workflowGraph = new StateGraph<RunGraphState>({
+  const graph = new StateGraph<RunGraphState>({
     channels: createStateGraphChannels({
       run,
       allAvailableTools,
@@ -75,5 +75,5 @@ export const createRunGraph = async ({
       postToolEdge(state, postStepSave),
     );
 
-  return workflowGraph.compile();
+  return graph.compile();
 };

--- a/control-plane/src/modules/runs/agent/nodes/model-call.test.ts
+++ b/control-plane/src/modules/runs/agent/nodes/model-call.test.ts
@@ -9,7 +9,7 @@ import { handleModelCall } from "./model-call";
 
 describe("handleModelCall", () => {
   const run = {
-    id: "test-workflow",
+    id: "test-run",
     clusterId: "test-cluster",
     reasoningTraces: true,
   };

--- a/control-plane/src/modules/runs/agent/run.test.ts
+++ b/control-plane/src/modules/runs/agent/run.test.ts
@@ -25,7 +25,7 @@ describe("findRelevantTools", () => {
       owner,
     });
 
-    const workflow = {
+    const run = {
       id: Math.random().toString(36).substring(2),
       clusterId: owner.clusterId,
       status: "running" as const,
@@ -33,7 +33,7 @@ describe("findRelevantTools", () => {
     };
 
     const tools = await findRelevantTools({
-      run: workflow,
+      run,
       messages: [
         {
           data: {
@@ -41,7 +41,7 @@ describe("findRelevantTools", () => {
           },
           type: "human" as const,
           clusterId: owner.clusterId,
-          runId: "test-workflow-id",
+          runId: "test-run-id",
           id: ulid(),
         },
       ],

--- a/control-plane/src/modules/runs/agent/summarizer.ts
+++ b/control-plane/src/modules/runs/agent/summarizer.ts
@@ -38,7 +38,7 @@ export const summariseJobResultIfNecessary = async (input: {
 
   logger.info(`Summarizing result because it is too large.`, {
     clusterId: input.clusterId,
-    workflowId: input.runId,
+    runId: input.runId,
     targetFn: input.targetFn,
   });
 

--- a/control-plane/src/modules/runs/agent/tools/cluster-internal-tools.ts
+++ b/control-plane/src/modules/runs/agent/tools/cluster-internal-tools.ts
@@ -13,7 +13,7 @@ const clusterSettingsCache = createCache<{
 }>(Symbol("clusterSettings"));
 
 export type InternalToolBuilder = (
-  workflow: Run,
+  run: Run,
   toolCallId: string
 ) => AgentTool | Promise<AgentTool>;
 

--- a/control-plane/src/modules/runs/queues.ts
+++ b/control-plane/src/modules/runs/queues.ts
@@ -94,7 +94,7 @@ async function handleRunProcess(message: unknown) {
     ]);
 
     if (!run) {
-      logger.error("Received job for unknown workflow");
+      logger.error("Received job for unknown Run");
       return;
     }
 
@@ -131,9 +131,9 @@ async function handleRunNameGeneration(message: unknown) {
   try {
     logger.info("Running name generation job");
 
-    const workflow = await getRun({ clusterId, runId });
+    const run = await getRun({ clusterId, runId });
 
-    const result = await generateTitle(content, workflow);
+    const result = await generateTitle(content, run);
 
     if (result.summary) {
       await updateRun({

--- a/control-plane/src/modules/runs/router.ts
+++ b/control-plane/src/modules/runs/router.ts
@@ -344,14 +344,14 @@ export const runsRouter = initServer().router(
       const auth = request.request.getAuth();
       await auth.canAccess({ run: { clusterId, runId } });
 
-      const { messages, activity, jobs, workflow } = await timeline.getRunTimeline({
+      const { messages, activity, jobs, run } = await timeline.getRunTimeline({
         clusterId,
         runId,
         messagesAfter,
         activityAfter,
       });
 
-      if (!workflow) {
+      if (!run) {
         return {
           status: 404,
         };
@@ -368,7 +368,7 @@ export const runsRouter = initServer().router(
           messages,
           activity,
           jobs,
-          run: workflow,
+          run,
           blobs,
         },
       };

--- a/control-plane/src/modules/timeline.ts
+++ b/control-plane/src/modules/timeline.ts
@@ -38,7 +38,7 @@ export const timeline = {
       await new Promise(resolve => setTimeout(resolve, delay));
     } while (rowsCount === 0 && Date.now() - startTime < timeout);
 
-    const [messages, activity, jobs, workflow] = await Promise.all([
+    const [messages, activity, jobs, run] = await Promise.all([
       getRunMessagesForDisplay({
         clusterId,
         runId,
@@ -63,7 +63,7 @@ export const timeline = {
       messages,
       activity,
       jobs,
-      workflow,
+      run,
     };
   },
 };


### PR DESCRIPTION
### **User description**
Resolves some agent tests issues introduced in #484


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed naming inconsistencies by renaming `workflow` to `run`.

- Updated test cases to align with new naming conventions.

- Adjusted logging and error messages for clarity.

- Refactored code to improve readability and maintainability.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>data.ts</strong><dd><code>Renamed `workflows` to `runs` and updated schema references.</code></dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/485/files#diff-389a480d000c3f91c0ca76b0cacd863c9db8ded03e464a9df80b7e905d233a05">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>agent.ts</strong><dd><code>Renamed `workflowGraph` to `graph` for clarity.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/485/files#diff-c15f97ee76155cb9059d46dd8e57b3154a669f24f9a1abd9809dd69758eca995">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cluster-internal-tools.ts</strong><dd><code>Changed parameter name from `workflow` to `run`.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/485/files#diff-8ffc1e6012fed6e4f44856372f8dcbb6df74ef8e56bfbef76ca20516777ac156">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>timeline.ts</strong><dd><code>Replaced `workflow` with `run` in timeline data handling.</code></dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/485/files#diff-60331093d60e7633025ab15b3d35520288f4d27955ff94a7bf67b26815e68143">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>agent.ai.test.ts</strong><dd><code>Updated test cases to replace `workflow` with `run`.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/485/files#diff-d00829363abd405bc3b579bc23b9a7ab722aefe0db0d1b169921bf25bd28c339">+21/-21</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>model-call.test.ts</strong><dd><code>Adjusted test data to use `run` instead of `workflow`.</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/485/files#diff-19b99eb8b6744ba95fb5da37c7e1208f817c90a125a22ab11a7e6337cdad9d9a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>run.test.ts</strong><dd><code>Replaced `workflow` with `run` in test cases.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/485/files#diff-db0388ffc2819a1a33fb428a036039c8f9c5cdb894c0b4d2c5f04e3f20757b0a">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>summarizer.ts</strong><dd><code>Updated logging to use `runId` instead of `workflowId`.</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/485/files#diff-d26a76f6ea19ed5a279025e94ee5d30e00aab980e77293d674b6431eb8e60493">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>queues.ts</strong><dd><code>Updated error messages and function calls to reflect `run`.</code></dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/485/files#diff-49fffbdfac51e614b9d57704f36c86f9413855a37f8c89f3e01db76cf2dbca5c">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>router.ts</strong><dd><code>Adjusted API responses to use `run` instead of `workflow`.</code></dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/485/files#diff-5430a559051514669149e61d634eec0047bb3622eae130e45ebf6921200c3285">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>package.json</strong><dd><code>Removed unused script related to workflows.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/485/files#diff-070cd4aad1ab03316d3296db441613c1bbf7a8b657272fbb00d52174e7ce048b">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information