### PR TITLE
feat: Support for triggering Agent from playground

### DIFF
--- a/app/components/chat/prompt-textarea.tsx
+++ b/app/components/chat/prompt-textarea.tsx
@@ -115,13 +115,6 @@ export function PromptTextarea({ clusterId }: { clusterId: string }) {
   }, [prompt]);
 
   useEffect(() => {
-    if (textareaRef.current) {
-      textareaRef.current.style.height = "auto";
-      textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
-    }
-  }, [prompt]);
-
-  useEffect(() => {
     const queryAgentId = searchParams?.get("agentId");
     if (queryAgentId) {
       setSelectedAgentId(queryAgentId);

--- a/app/components/chat/prompt-textarea.tsx
+++ b/app/components/chat/prompt-textarea.tsx
@@ -9,7 +9,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { cn, createErrorToast } from "@/lib/utils";
 import { useAuth } from "@clerk/nextjs";
 import { ClientInferRequest, ClientInferResponseBody } from "@ts-rest/core";
-import { Bot, ChevronDown, ChevronRight, PlusCircleIcon, Settings2Icon } from "lucide-react";
+import { Bot, ChevronDown, ChevronRight, Cog, PlusCircleIcon, Settings2Icon } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "../ui/button";
@@ -310,7 +310,7 @@ export function PromptTextarea({ clusterId }: { clusterId: string }) {
             <span className="font-medium uppercase tracking-wider">Configuration</span>
           </div>
           <p className="text-xs text-muted-foreground mt-2">
-            Configure how the Agent processes your request and interacts with available tools.
+            Configure how Inferable will process your request and interact with available tools.
           </p>
         </div>
 
@@ -326,20 +326,22 @@ export function PromptTextarea({ clusterId }: { clusterId: string }) {
         >
           <div className="border-b">
             <TabsList className="w-full justify-start bg-transparent h-auto p-0">
-              <TabsTrigger
-                value="custom"
-                className="data-[state=active]:bg-transparent data-[state=active]:shadow-none data-[state=active]:border-b-2 data-[state=active]:border-primary rounded-none px-3 py-2 text-xs"
-              >
-                Custom
-              </TabsTrigger>
               {agents && agents.length > 0 && (
                 <TabsTrigger
                   value="agent"
                   className="data-[state=active]:bg-transparent data-[state=active]:shadow-none data-[state=active]:border-b-2 data-[state=active]:border-primary rounded-none px-3 py-2 text-xs"
                 >
-                  Use Agent
+                  <Bot className="mr-2 h-3.5 w-3.5" />
+                  Agents
                 </TabsTrigger>
               )}
+              <TabsTrigger
+                value="custom"
+                className="data-[state=active]:bg-transparent data-[state=active]:shadow-none data-[state=active]:border-b-2 data-[state=active]:border-primary rounded-none px-3 py-2 text-xs"
+              >
+                <Cog className="mr-2 h-3.5 w-3.5" />
+                Custom
+              </TabsTrigger>
             </TabsList>
           </div>
 
@@ -395,7 +397,7 @@ export function PromptTextarea({ clusterId }: { clusterId: string }) {
                 Define a JSON schema to get structured output from the AI. The agent will format its
                 response to match your specified schema. See the{" "}
                 <a
-                  className="text-blue-500 hover:underline"
+                  className="text-xs text-primary hover:text-primary/90 hover:underline"
                   href="https://docs.inferable.ai/pages/runs#resultschema"
                 >
                   {" "}
@@ -452,7 +454,7 @@ export function PromptTextarea({ clusterId }: { clusterId: string }) {
                 Provide additional context as JSON that will be passed into all function calls. It
                 is <span className="font-bold">not</span> visible to the agent. See the{" "}
                 <a
-                  className="text-blue-500 hover:underline"
+                  className="text-xs text-primary hover:text-primary/90 hover:underline"
                   href="https://docs.inferable.ai/pages/runs#context"
                 >
                   {" "}
@@ -549,6 +551,11 @@ export function PromptTextarea({ clusterId }: { clusterId: string }) {
               {agents && agents.length > 0 ? (
                 <div>
                   <div className="mb-6">
+                    <p className="text-sm text-muted-foreground mb-4">
+                      Select from one of the Cluster&apos;s existing <a className="text-xs text-primary hover:text-primary/90 hover:underline"
+                                href={`/clusters/${clusterId}/agents`}>Agents</a>.
+
+                    </p>
                     <div className="flex flex-wrap gap-2">
                       {agents.map(agent => (
                         <Button
@@ -576,7 +583,7 @@ export function PromptTextarea({ clusterId }: { clusterId: string }) {
                       if (!agent) return null;
                       return (
                         <div className="space-y-6 bg-muted/30 rounded-lg p-4">
-                          <div className="border-b pb-4">
+                          <div className="border-b">
                             <div className="flex items-start justify-between">
                               <div>
                                 <h3 className="text-sm font-medium">{agent.name}</h3>
@@ -628,7 +635,7 @@ export function PromptTextarea({ clusterId }: { clusterId: string }) {
                     No Agents found for this Cluster
                   </p>
                   <a
-                    className="text-sm text-primary hover:text-primary/90 hover:underline"
+                    className="text-xs text-primary hover:text-primary/90 hover:underline"
                     href={`/clusters/${clusterId}/agents`}
                   >
                     Create your first agent

--- a/app/components/chat/prompt-textarea.tsx
+++ b/app/components/chat/prompt-textarea.tsx
@@ -9,20 +9,23 @@ import { Textarea } from "@/components/ui/textarea";
 import { cn, createErrorToast } from "@/lib/utils";
 import { useAuth } from "@clerk/nextjs";
 import { ClientInferRequest, ClientInferResponseBody } from "@ts-rest/core";
-import {
-  Bot,
-  ChevronDown,
-  ChevronRight,
-  PlusCircleIcon,
-  Settings2Icon,
-} from "lucide-react";
+import { Bot, ChevronDown, ChevronRight, PlusCircleIcon, Settings2Icon } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "../ui/button";
 import Commands from "./sdk-commands";
 import { isFeatureEnabled } from "@/lib/features";
-import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from "../ui/select";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../ui/select";
 import toast from "react-hot-toast";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
+import { Badge } from "../ui/badge";
 
 export type RunOptions = {
   agentId?: string;
@@ -65,7 +68,6 @@ export function PromptTextarea({ clusterId }: { clusterId: string }) {
     setOptions(newConfig);
   };
 
-
   const [agents, setAgents] = useState<ClientInferResponseBody<
     typeof contract.listAgents,
     200
@@ -74,7 +76,6 @@ export function PromptTextarea({ clusterId }: { clusterId: string }) {
   const [selectedAgentId, setSelectedAgentId] = useState<string | undefined>(undefined);
 
   const searchParams = useSearchParams();
-
 
   useEffect(() => {
     if (agents) {
@@ -85,16 +86,16 @@ export function PromptTextarea({ clusterId }: { clusterId: string }) {
           reasoningTraces: true,
           resultSchema: null,
           runContext: null,
-        })
-        return
+        });
+        return;
       }
 
-      const agent = agents.find((agent) => agent.id === selectedAgentId);
+      const agent = agents.find(agent => agent.id === selectedAgentId);
 
       if (!agent) {
         toast.error("Could not find Agent with ID: " + selectedAgentId);
         setSelectedAgentId(undefined);
-        return
+        return;
       }
 
       setOptions({
@@ -103,7 +104,7 @@ export function PromptTextarea({ clusterId }: { clusterId: string }) {
         reasoningTraces: true,
         resultSchema: agent.resultSchema ? JSON.stringify(agent.resultSchema, null, 2) : null,
         runContext: null,
-      })
+      });
     }
   }, [selectedAgentId, agents]);
 
@@ -119,7 +120,7 @@ export function PromptTextarea({ clusterId }: { clusterId: string }) {
     if (queryAgentId) {
       setSelectedAgentId(queryAgentId);
     }
-  }, [ searchParams, setSelectedAgentId ]);
+  }, [searchParams, setSelectedAgentId]);
 
   const onSubmit = useCallback(
     async (options: RunOptions) => {
@@ -134,7 +135,7 @@ export function PromptTextarea({ clusterId }: { clusterId: string }) {
       }
 
       if (options.attachedFunctions && options.attachedFunctions.length > 0) {
-        body.attachedFunctions = options.attachedFunctions?.map((fn) => {
+        body.attachedFunctions = options.attachedFunctions?.map(fn => {
           const [service, functionName] = fn.split("_");
 
           return {
@@ -214,8 +215,8 @@ export function PromptTextarea({ clusterId }: { clusterId: string }) {
       });
 
       if (result.status === 200) {
-        const functions = result.body.flatMap((service) =>
-          (service.functions || []).map((fn) => ({
+        const functions = result.body.flatMap(service =>
+          (service.functions || []).map(fn => ({
             value: `${service.name}_${fn.name}`,
             label: `${service.name}.${fn.name}`,
           }))
@@ -248,10 +249,7 @@ export function PromptTextarea({ clusterId }: { clusterId: string }) {
     fetchAgents();
   }, [clusterId, selectedAgentId, getToken, setAgents]);
 
-
-  const [collapsedSections, setCollapsedSections] = useState<
-    Record<string, boolean>
-  >({
+  const [collapsedSections, setCollapsedSections] = useState<Record<string, boolean>>({
     functions: true,
     schema: true,
     context: true,
@@ -259,7 +257,7 @@ export function PromptTextarea({ clusterId }: { clusterId: string }) {
   });
 
   const toggleSection = (section: string) => {
-    setCollapsedSections((prev) => ({
+    setCollapsedSections(prev => ({
       ...prev,
       [section]: !prev[section],
     }));
@@ -274,24 +272,30 @@ export function PromptTextarea({ clusterId }: { clusterId: string }) {
     });
   };
 
+  const [activeTab, setActiveTab] = useState<string>("custom");
+
+  useEffect(() => {
+    const queryAgentId = searchParams?.get("agentId");
+    if (queryAgentId) {
+      setSelectedAgentId(queryAgentId);
+      setActiveTab("agent");
+    }
+  }, [searchParams, setSelectedAgentId]);
+
   return (
     <div className="space-y-6">
       <div className="space-y-2">
         <div className="flex items-center gap-2">
           <PlusCircleIcon className="h-5 w-5 text-gray-600" />
-          <h2 className="text-lg font-medium tracking-tight text-gray-600">
-            Start a new run
-          </h2>
-          <span className="text-xs text-muted-foreground mt-1">
-            Press ⌘ + Enter to send
-          </span>
+          <h2 className="text-lg font-medium tracking-tight text-gray-600">Start a new run</h2>
+          <span className="text-xs text-muted-foreground mt-1">Press ⌘ + Enter to send</span>
         </div>
         <Textarea
           ref={textareaRef}
           rows={1}
           placeholder="What would you like me to help you with?"
           value={prompt}
-          onChange={(e) => {
+          onChange={e => {
             setPrompt(e.target.value);
           }}
           onKeyDown={handleKeyDown}
@@ -299,299 +303,341 @@ export function PromptTextarea({ clusterId }: { clusterId: string }) {
         />
       </div>
 
-      <div className="space-y-2 border rounded-lg bg-gray-50/30 divide-y divide-gray-100/50">
+      <div className="space-y-2 border rounded-lg bg-gray-50/30">
         <div className="p-3">
-          <button
-            onClick={() =>
-              toggleAllSections(
-                !Object.values(collapsedSections).every((v) => v)
-              )
-            }
-            className="flex items-center gap-2 text-xs text-muted-foreground w-full hover:text-primary transition-colors"
-          >
+          <div className="flex items-center gap-2 text-xs text-muted-foreground w-full">
             <Settings2Icon className="h-3.5 w-3.5" />
-            <span className="font-medium uppercase tracking-wider">
-              Configuration
-            </span>
-            {Object.values(collapsedSections).every((v) => v) ? (
-              <ChevronRight className="h-3.5 w-3.5 ml-auto" />
-            ) : (
-              <ChevronDown className="h-3.5 w-3.5 ml-auto" />
-            )}
-          </button>
+            <span className="font-medium uppercase tracking-wider">Configuration</span>
+          </div>
           <p className="text-xs text-muted-foreground mt-2">
-            Configure how the AI agent processes your request and interacts with
-            available tools.
+            Configure how the Agent processes your request and interacts with available tools.
           </p>
         </div>
 
-        {/* Agent Section */}
-        <div className="px-3 py-2">
-          <div
-            className="flex items-center gap-2 w-full text-xs hover:text-primary transition-colors"
-          >
-            <Bot className="h-3.5 w-3.5" />
-            <span className="font-medium">Agent</span>
+        <Tabs
+          value={activeTab}
+          className="w-full"
+          onValueChange={value => {
+            setActiveTab(value);
+            if (value === "custom") {
+              setSelectedAgentId(undefined);
+            }
+          }}
+        >
+          <div className="border-b">
+            <TabsList className="w-full justify-start bg-transparent h-auto p-0">
+              <TabsTrigger
+                value="custom"
+                className="data-[state=active]:bg-transparent data-[state=active]:shadow-none data-[state=active]:border-b-2 data-[state=active]:border-primary rounded-none px-3 py-2 text-xs"
+              >
+                Custom
+              </TabsTrigger>
+              {agents && agents.length > 0 && (
+                <TabsTrigger
+                  value="agent"
+                  className="data-[state=active]:bg-transparent data-[state=active]:shadow-none data-[state=active]:border-b-2 data-[state=active]:border-primary rounded-none px-3 py-2 text-xs"
+                >
+                  Use Agent
+                </TabsTrigger>
+              )}
+            </TabsList>
           </div>
-          {agents && agents.length > 0 && (
-            <div>
-            <p className="text-xs text-muted-foreground mt-1 mb-2">
-                Configure this Run using an <a className="text-blue-500 hover:underline" href={`/clusters/${clusterId}/agents`}>Agent</a>
-            </p>
-            <Select onValueChange={(selected) => selected == "none" ? setSelectedAgentId(undefined) : setSelectedAgentId(selected)} value={selectedAgentId ?? "none"}>
-              <SelectTrigger>
-                <SelectValue placeholder="Select an Agent" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectGroup>
-                  {agents.map((agent) => (
-                    <SelectItem
-                      key={agent.id}
-                      value={agent.id}
-                    >
-                      {agent.name}
-                    </SelectItem>
-                  ))}
-                  <SelectItem key="none" value={"none"}>None</SelectItem>
-                </SelectGroup>
-              </SelectContent>
-            </Select>
-            </div>
-          )}
 
-          {agents && agents.length === 0 && (
-            <p className="text-xs text-muted-foreground mt-2">
-              No Agents found for this Cluster. <a className="text-blue-500 hover:underline" href={`/clusters/${clusterId}/agents`}>Create one here</a>.
-            </p>
-          )}
-
-          { !!selectedAgentId && (
-            <p className="text-md text-muted-foreground mt-2">
-              Run options can not be configured when using an Agent.
-              The Run options will be those defined by <a className="text-blue-500 hover:underline" href={`/clusters/${clusterId}/agents/${selectedAgentId}/edit`}>Agent {selectedAgentId}</a>
-            </p>
-          )}
-        </div>
-
-        {/* Functions Section */}
-        <div className="px-3 py-2">
-          <button
-            className="flex items-center gap-2 w-full text-xs hover:text-primary transition-colors"
-            onClick={() => toggleSection("functions")}
-          >
-            {collapsedSections.functions ? (
-              <ChevronRight className="h-3.5 w-3.5" />
-            ) : (
-              <ChevronDown className="h-3.5 w-3.5" />
-            )}
-            <span className="font-medium">Attached Functions</span>
-            <span className="text-[11px] text-muted-foreground ml-2">
-              {options.attachedFunctions.length} selected
-            </span>
-          </button>
-          <p className="text-xs text-muted-foreground mt-1 mb-2">
-            Select tools and APIs that the AI can use to help complete your
-            request. The agent will automatically determine when to use these
-            functions.
-          </p>
-          <div className={cn("mt-2", collapsedSections.functions && "hidden")}>
-            { !!selectedAgentId ? (
-              <pre className="bg-gray-5 border rounded-md p-2">
-                {JSON.stringify(options.attachedFunctions, null, 2)}
-              </pre>
-
-            ) : (
-              <MultiSelect
-                value={options.attachedFunctions}
-                onChange={(value) =>
-                  handleOptionsChange({
-                    ...options,
-                    attachedFunctions: value,
-                  })
-                }
-                options={availableFunctions}
-              />
-            )}
-
-          </div>
-        </div>
-
-        {/* Schema Section */}
-        <div className="px-3 py-2">
-          <button
-            className="flex items-center gap-2 w-full text-xs hover:text-primary transition-colors"
-            onClick={() => toggleSection("schema")}
-          >
-            {collapsedSections.schema ? (
-              <ChevronRight className="h-3.5 w-3.5" />
-            ) : (
-              <ChevronDown className="h-3.5 w-3.5" />
-            )}
-            <span className="font-medium">Result Schema</span>
-          </button>
-          <p className="text-xs text-muted-foreground mt-1 mb-2">
-            Define a JSON schema to get structured output from the AI. The agent
-            will format its response to match your specified schema.
-            See the <a
-                        className="text-blue-500 hover:underline"
-                        href="https://docs.inferable.ai/pages/runs#resultschema"
-                      > Docs</a> for details.
-          </p>
-          <div
-            className={cn(
-              "mt-2 space-y-2",
-              collapsedSections.schema && "hidden"
-            )}
-          >
-            <Textarea
-              value={options.resultSchema || ""}
-              disabled={!!selectedAgentId}
-              onChange={(e) =>
-                handleOptionsChange({
-                  ...options,
-                  resultSchema: e.target.value,
-                })
-              }
-              placeholder="Enter JSON schema..."
-              className="font-mono text-xs bg-white/50"
-            />
-            {options.resultSchema && (
-              <div className="rounded-md overflow-hidden border border-gray-100">
-                {(() => {
-                  try {
-                    JSON.parse(options.resultSchema);
-                    return <ReadOnlyJSON json={options.resultSchema} />;
-                  } catch (e) {
-                    return (
-                      <div className="text-[11px] text-red-600 bg-red-50 p-2 border-t">
-                        Invalid JSON schema
-                      </div>
-                    );
-                  }
-                })()}
-              </div>
-            )}
-          </div>
-        </div>
-
-        {/* Context Section */}
-        <div className="px-3 py-2">
-          <button
-            className="flex items-center gap-2 w-full text-xs hover:text-primary transition-colors"
-            onClick={() => toggleSection("context")}
-          >
-            {collapsedSections.context ? (
-              <ChevronRight className="h-3.5 w-3.5" />
-            ) : (
-              <ChevronDown className="h-3.5 w-3.5" />
-            )}
-            <span className="font-medium">Run Context</span>
-          </button>
-          <p className="text-xs text-muted-foreground mt-1 mb-2">
-
-            Provide additional context as JSON that will be passed into all function calls.
-            It is <span className="font-bold">not</span> visible to the agent.
-            See the <a
-                        className="text-blue-500 hover:underline"
-                        href="https://docs.inferable.ai/pages/runs#context"
-                      > Docs</a> for details.
-          </p>
-          <div
-            className={cn(
-              "mt-2 space-y-2",
-              collapsedSections.context && "hidden"
-            )}
-          >
-            <Textarea
-              value={options.runContext || ""}
-              disabled={!!selectedAgentId}
-              onChange={(e) =>
-                handleOptionsChange({
-                  ...options,
-                  runContext: e.target.value,
-                })
-              }
-              placeholder="Enter context as JSON..."
-              className="font-mono text-xs bg-white/50"
-            />
-            {options.runContext && (
-              <div className="rounded-md overflow-hidden border border-gray-100">
-                {(() => {
-                  try {
-                    JSON.parse(options.runContext);
-                    return <ReadOnlyJSON json={options.runContext} />;
-                  } catch (e) {
-                    return (
-                      <div className="text-[11px] text-red-600 bg-red-50 p-2 border-t">
-                        Invalid JSON context
-                      </div>
-                    );
-                  }
-                })()}
-              </div>
-            )}
-          </div>
-        </div>
-
-        {/* Options Section */}
-        <div className="px-3 py-2">
-          <button
-            className="flex items-center gap-2 w-full text-xs hover:text-primary transition-colors"
-            onClick={() => toggleSection("options")}
-          >
-            {collapsedSections.options ? (
-              <ChevronRight className="h-3.5 w-3.5" />
-            ) : (
-              <ChevronDown className="h-3.5 w-3.5" />
-            )}
-            <span className="font-medium">Options</span>
-          </button>
-          <p className="text-xs text-muted-foreground mt-1 mb-2">
-            Configure how the AI agent processes your request and interacts with
-            available tools.
-          </p>
-          <div
-            className={cn(
-              "mt-2 space-y-4",
-              collapsedSections.options && "hidden"
-            )}
-          >
-            <div className="flex items-center space-x-2">
-              <Switch
-                checked={options.reasoningTraces}
-                disabled={!!selectedAgentId}
-                onCheckedChange={(checked) =>
-                  handleOptionsChange({
-                    ...options,
-                    reasoningTraces: checked,
-                  })
-                }
-                className="scale-75 data-[state=checked]:bg-primary"
-              />
-              <label className="text-xs text-muted-foreground">
-                Enable reasoning traces
-              </label>
-            </div>
-            {isFeatureEnabled("feature.result_grounding") && (
-              <div className={"flex items-center space-x-2"}>
-                <Switch
-                  checked={options.enableResultGrounding}
-                  disabled={!!selectedAgentId}
-                  onCheckedChange={(checked) =>
+          <TabsContent value="custom" className="mt-0">
+            {/* Functions Section */}
+            <div className="px-3 py-4 border-b">
+              <button
+                className="flex items-center gap-2 w-full text-xs hover:text-primary transition-colors"
+                onClick={() => toggleSection("functions")}
+              >
+                {collapsedSections.functions ? (
+                  <ChevronRight className="h-3.5 w-3.5" />
+                ) : (
+                  <ChevronDown className="h-3.5 w-3.5" />
+                )}
+                <span className="font-medium">Attached Functions</span>
+                <span className="text-[11px] text-muted-foreground ml-2">
+                  {options.attachedFunctions.length} selected
+                </span>
+              </button>
+              <p className="text-xs text-muted-foreground mt-1 mb-2">
+                Select tools and APIs that the AI can use to help complete your request. The agent
+                will automatically determine when to use these functions.
+              </p>
+              <div className={cn("mt-2", collapsedSections.functions && "hidden")}>
+                <MultiSelect
+                  value={options.attachedFunctions}
+                  onChange={value =>
                     handleOptionsChange({
                       ...options,
-                      enableResultGrounding: checked,
+                      attachedFunctions: value,
                     })
                   }
-                  className="scale-75 data-[state=checked]:bg-primary"
+                  options={availableFunctions}
                 />
-                <label className="text-xs text-muted-foreground">
-                  Enable result grounding
-                </label>
               </div>
-            )}
-          </div>
-        </div>
+            </div>
+
+            {/* Schema Section */}
+            <div className="px-3 py-4 border-b">
+              <button
+                className="flex items-center gap-2 w-full text-xs hover:text-primary transition-colors"
+                onClick={() => toggleSection("schema")}
+              >
+                {collapsedSections.schema ? (
+                  <ChevronRight className="h-3.5 w-3.5" />
+                ) : (
+                  <ChevronDown className="h-3.5 w-3.5" />
+                )}
+                <span className="font-medium">Result Schema</span>
+              </button>
+              <p className="text-xs text-muted-foreground mt-1 mb-2">
+                Define a JSON schema to get structured output from the AI. The agent will format its
+                response to match your specified schema. See the{" "}
+                <a
+                  className="text-blue-500 hover:underline"
+                  href="https://docs.inferable.ai/pages/runs#resultschema"
+                >
+                  {" "}
+                  Docs
+                </a>{" "}
+                for details.
+              </p>
+              <div className={cn("mt-2 space-y-2", collapsedSections.schema && "hidden")}>
+                <Textarea
+                  value={options.resultSchema || ""}
+                  disabled={!!selectedAgentId}
+                  onChange={e =>
+                    handleOptionsChange({
+                      ...options,
+                      resultSchema: e.target.value,
+                    })
+                  }
+                  placeholder="Enter JSON schema..."
+                  className="font-mono text-xs bg-white/50"
+                />
+                {options.resultSchema && (
+                  <div className="rounded-md overflow-hidden border border-gray-100">
+                    {(() => {
+                      try {
+                        JSON.parse(options.resultSchema);
+                        return <ReadOnlyJSON json={options.resultSchema} />;
+                      } catch (e) {
+                        return (
+                          <div className="text-[11px] text-red-600 bg-red-50 p-2 border-t">
+                            Invalid JSON schema
+                          </div>
+                        );
+                      }
+                    })()}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* Context Section */}
+            <div className="px-3 py-4 border-b">
+              <button
+                className="flex items-center gap-2 w-full text-xs hover:text-primary transition-colors"
+                onClick={() => toggleSection("context")}
+              >
+                {collapsedSections.context ? (
+                  <ChevronRight className="h-3.5 w-3.5" />
+                ) : (
+                  <ChevronDown className="h-3.5 w-3.5" />
+                )}
+                <span className="font-medium">Run Context</span>
+              </button>
+              <p className="text-xs text-muted-foreground mt-1 mb-2">
+                Provide additional context as JSON that will be passed into all function calls. It
+                is <span className="font-bold">not</span> visible to the agent. See the{" "}
+                <a
+                  className="text-blue-500 hover:underline"
+                  href="https://docs.inferable.ai/pages/runs#context"
+                >
+                  {" "}
+                  Docs
+                </a>{" "}
+                for details.
+              </p>
+              <div className={cn("mt-2 space-y-2", collapsedSections.context && "hidden")}>
+                <Textarea
+                  value={options.runContext || ""}
+                  disabled={!!selectedAgentId}
+                  onChange={e =>
+                    handleOptionsChange({
+                      ...options,
+                      runContext: e.target.value,
+                    })
+                  }
+                  placeholder="Enter context as JSON..."
+                  className="font-mono text-xs bg-white/50"
+                />
+                {options.runContext && (
+                  <div className="rounded-md overflow-hidden border border-gray-100">
+                    {(() => {
+                      try {
+                        JSON.parse(options.runContext);
+                        return <ReadOnlyJSON json={options.runContext} />;
+                      } catch (e) {
+                        return (
+                          <div className="text-[11px] text-red-600 bg-red-50 p-2 border-t">
+                            Invalid JSON context
+                          </div>
+                        );
+                      }
+                    })()}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* Options Section */}
+            <div className="px-3 py-4">
+              <button
+                className="flex items-center gap-2 w-full text-xs hover:text-primary transition-colors"
+                onClick={() => toggleSection("options")}
+              >
+                {collapsedSections.options ? (
+                  <ChevronRight className="h-3.5 w-3.5" />
+                ) : (
+                  <ChevronDown className="h-3.5 w-3.5" />
+                )}
+                <span className="font-medium">Options</span>
+              </button>
+              <p className="text-xs text-muted-foreground mt-1 mb-2">
+                Configure how the AI agent processes your request and interacts with available
+                tools.
+              </p>
+              <div className={cn("mt-2 space-y-4", collapsedSections.options && "hidden")}>
+                <div className="flex items-center space-x-2">
+                  <Switch
+                    checked={options.reasoningTraces}
+                    disabled={!!selectedAgentId}
+                    onCheckedChange={checked =>
+                      handleOptionsChange({
+                        ...options,
+                        reasoningTraces: checked,
+                      })
+                    }
+                    className="scale-75 data-[state=checked]:bg-primary"
+                  />
+                  <label className="text-xs text-muted-foreground">Enable reasoning traces</label>
+                </div>
+                {isFeatureEnabled("feature.result_grounding") && (
+                  <div className={"flex items-center space-x-2"}>
+                    <Switch
+                      checked={options.enableResultGrounding}
+                      disabled={!!selectedAgentId}
+                      onCheckedChange={checked =>
+                        handleOptionsChange({
+                          ...options,
+                          enableResultGrounding: checked,
+                        })
+                      }
+                      className="scale-75 data-[state=checked]:bg-primary"
+                    />
+                    <label className="text-xs text-muted-foreground">Enable result grounding</label>
+                  </div>
+                )}
+              </div>
+            </div>
+          </TabsContent>
+
+          <TabsContent value="agent" className="mt-0">
+            <div className="p-4">
+              {agents && agents.length > 0 ? (
+                <div>
+                  <div className="mb-6">
+                    <div className="flex flex-wrap gap-2">
+                      {agents.map(agent => (
+                        <Button
+                          size="sm"
+                          key={agent.id}
+                          variant={selectedAgentId === agent.id ? "default" : "outline"}
+                          className={cn(
+                            "cursor-pointer transition-colors px-4 py-1",
+                            selectedAgentId === agent.id
+                              ? "hover:bg-primary/90"
+                              : "hover:border-primary/50"
+                          )}
+                          onClick={() => setSelectedAgentId(agent.id)}
+                        >
+                          {agent.name}
+                        </Button>
+                      ))}
+                    </div>
+                  </div>
+
+                  {selectedAgentId &&
+                    agents &&
+                    (() => {
+                      const agent = agents.find(a => a.id === selectedAgentId);
+                      if (!agent) return null;
+                      return (
+                        <div className="space-y-6 bg-muted/30 rounded-lg p-4">
+                          <div className="border-b pb-4">
+                            <div className="flex items-start justify-between">
+                              <div>
+                                <h3 className="text-sm font-medium">{agent.name}</h3>
+                                <p className="text-xs text-muted-foreground mt-1">
+                                  Using predefined configuration from this agent
+                                </p>
+                              </div>
+                              <a
+                                className="text-xs text-primary hover:text-primary/90 hover:underline"
+                                href={`/clusters/${clusterId}/agents/${selectedAgentId}/edit`}
+                              >
+                                Edit Configuration
+                              </a>
+                            </div>
+                          </div>
+
+                          <div className="space-y-4">
+                            {options.attachedFunctions.length > 0 && (
+                              <div>
+                                <div className="flex items-center gap-2 mb-2">
+                                  <span className="h-1 w-1 rounded-full bg-primary/70"></span>
+                                  <h4 className="text-xs font-medium">Attached Functions</h4>
+                                </div>
+                                <pre className="text-xs bg-background rounded-md p-3 overflow-auto border">
+                                  {options.attachedFunctions.join(", ")}
+                                </pre>
+                              </div>
+                            )}
+
+                            {options.resultSchema && (
+                              <div>
+                                <div className="flex items-center gap-2 mb-2">
+                                  <span className="h-1 w-1 rounded-full bg-primary/70"></span>
+                                  <h4 className="text-xs font-medium">Result Schema</h4>
+                                </div>
+                                <pre className="text-xs bg-background rounded-md p-3 overflow-auto border">
+                                  {options.resultSchema}
+                                </pre>
+                              </div>
+                            )}
+                          </div>
+                        </div>
+                      );
+                    })()}
+                </div>
+              ) : (
+                <div className="text-center py-8">
+                  <p className="text-sm text-muted-foreground mb-2">
+                    No Agents found for this Cluster
+                  </p>
+                  <a
+                    className="text-sm text-primary hover:text-primary/90 hover:underline"
+                    href={`/clusters/${clusterId}/agents`}
+                  >
+                    Create your first agent
+                  </a>
+                </div>
+              )}
+            </div>
+          </TabsContent>
+        </Tabs>
       </div>
 
       <div className="flex gap-2">

--- a/app/components/workflow.tsx
+++ b/app/components/workflow.tsx
@@ -464,15 +464,12 @@ export function Run({ clusterId, runId }: { clusterId: string; runId: string }) 
               )}
 
               {run.status === "failed" && (
-                <div className="flex items-center space-x-2 ml-auto">
-                  <div className="bg-red-50 p-1.5 rounded">
-                    <MessageCircleWarning className="h-4 w-4 text-red-500" />
-                  </div>
-                  <span className="text-sm text-red-600">Failed: {run.failureReason}</span>
-                  <Button
+                <div className="flex flex-row">
+                  <MessageCircleWarning className="h-4 w-4 mt-1 text-red-500" />
+                  <span className="text-sm text-red-600 px-2">Failed: {run.failureReason}</span> <Button
                     size="sm"
                     variant="outline"
-                    className="h-7"
+                    className="h-7 align-end ml-auto"
                     onClick={async () => {
                       const loading = toast.loading("Retrying run...");
 


### PR DESCRIPTION
### **User description**
- Allow Agent's to be selected within the Playground's "Start Run" pane
- If an Agent is selected, the Run options are **not editable**
- Fix the Agent's page "Run" button which redirects to `/runs` with `agentId` query param.

https://github.com/user-attachments/assets/6f3680f2-7808-436d-bf5a-23fd3c20aea2


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added support for selecting and triggering Agents in the Playground.

- Enhanced UI to display Agent-specific configurations and restrictions.

- Refactored `PromptTextarea` to handle Agent-specific options dynamically.

- Improved error handling and user feedback for Agent and function selection.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>prompt-textarea.tsx</strong><dd><code>Refactor and enhance Agent selection in Playground</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/components/chat/prompt-textarea.tsx

<li>Added Agent selection dropdown and related UI elements.<br> <li> Refactored <code>RunOptions</code> to include Agent-specific configurations.<br> <li> Improved error handling for Agent and function fetching.<br> <li> Disabled editable options when an Agent is selected.


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/487/files#diff-0804a76578a0fc8aae7540609d142f71d3177149430173d60e44fecf8f907224">+204/-165</a></td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workflow.tsx</strong><dd><code>Improve UI for failed run status</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/components/workflow.tsx

<li>Adjusted UI for failed run status display.<br> <li> Improved alignment and styling for failure messages and retry button.


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/487/files#diff-3869bd7c46b85e34e1b64ec4f754b5872b864e1fa5b62051fb65f2af161b9530">+4/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information