### PR TITLE
chore: Call -> Job rename

### DIFF
--- a/app/client/contract.ts
+++ b/app/client/contract.ts
@@ -280,13 +280,13 @@ export const definition = {
   },
 
   // Job Endpoints
-  getCall: {
+  getJob: {
     method: "GET",
-    path: "/clusters/:clusterId/calls/:callId",
+    path: "/clusters/:clusterId/jobs/:jobId",
     headers: z.object({ authorization: z.string() }),
     pathParams: z.object({
       clusterId: z.string(),
-      callId: z.string(),
+      jobId: z.string(),
     }),
     responses: {
       200: z.object({
@@ -303,9 +303,9 @@ export const definition = {
       }),
     },
   },
-  createCall: {
+  createJob: {
     method: "POST",
-    path: "/clusters/:clusterId/calls",
+    path: "/clusters/:clusterId/jobs",
     query: z.object({
       waitTime: z.coerce
         .number()
@@ -332,16 +332,16 @@ export const definition = {
       }),
     },
   },
-  createCallResult: {
+  createJobResult: {
     method: "POST",
-    path: "/clusters/:clusterId/calls/:callId/result",
+    path: "/clusters/:clusterId/jobs/:jobId/result",
     headers: z.object({
       authorization: z.string(),
       ...machineHeaders,
     }),
     pathParams: z.object({
       clusterId: z.string(),
-      callId: z.string(),
+      jobId: z.string(),
     }),
     responses: {
       204: z.undefined(),
@@ -355,14 +355,14 @@ export const definition = {
       }),
     }),
   },
-  listCalls: {
+  listJobs: {
     method: "GET",
-    path: "/clusters/:clusterId/calls",
+    path: "/clusters/:clusterId/jobs",
     query: z.object({
       service: z.string(),
       status: z.enum(["pending", "running", "paused", "done", "failed"]).default("pending"),
       limit: z.coerce.number().min(1).max(20).default(10),
-      acknowledge: z.coerce.boolean().default(false).describe("Should calls be marked as running"),
+      acknowledge: z.coerce.boolean().default(false).describe("Should retrieved Jobs be marked as running"),
     }),
     pathParams: z.object({
       clusterId: z.string(),
@@ -388,15 +388,15 @@ export const definition = {
       ),
     },
   },
-  createCallApproval: {
+  createJobApproval: {
     method: "POST",
-    path: "/clusters/:clusterId/calls/:callId/approval",
+    path: "/clusters/:clusterId/jobs/:jobId/approval",
     headers: z.object({
       authorization: z.string(),
     }),
     pathParams: z.object({
       clusterId: z.string(),
-      callId: z.string(),
+      jobId: z.string(),
     }),
     responses: {
       204: z.undefined(),
@@ -408,9 +408,9 @@ export const definition = {
       approved: z.boolean(),
     }),
   },
-  createCallBlob: {
+  createJobBlob: {
     method: "POST",
-    path: "/clusters/:clusterId/calls/:callId/blobs",
+    path: "/clusters/:clusterId/jobs/:jobId/blobs",
     headers: z.object({
       authorization: z.string(),
       "x-machine-id": z.string(),
@@ -421,7 +421,7 @@ export const definition = {
     }),
     pathParams: z.object({
       clusterId: z.string(),
-      callId: z.string(),
+      jobId: z.string(),
     }),
     responses: {
       201: z.object({
@@ -763,7 +763,7 @@ export const definition = {
         .optional(),
       context: anyObject
         .optional()
-        .describe("Additional context to propogate to all calls in the run"),
+        .describe("Additional context to propogate to all Jobs in the Run"),
       reasoningTraces: z.boolean().default(true).optional().describe("Enable reasoning traces"),
       callSummarization: z
         .boolean()

--- a/app/components/chat/function-call.tsx
+++ b/app/components/chat/function-call.tsx
@@ -90,7 +90,7 @@ function FunctionCall({
   const [editing, setEditing] = useState(false);
 
   const [job, setJob] = useState<Partial<
-    ClientInferResponseBody<typeof contract.getCall>
+    ClientInferResponseBody<typeof contract.getJob>
   > | null>(null);
 
   const completedWithRejection =
@@ -99,9 +99,9 @@ function FunctionCall({
   const { getToken } = useAuth();
 
   const getJobDetail = useCallback(async () => {
-    const result = await client.getCall({
+    const result = await client.getJob({
       params: {
-        callId: jobId,
+        jobId,
         clusterId,
       },
       headers: {

--- a/app/components/workflow.tsx
+++ b/app/components/workflow.tsx
@@ -225,18 +225,18 @@ export function Run({ clusterId, runId }: { clusterId: string; runId: string }) 
   const submitApproval = useCallback(
     async ({
       approved,
-      callId,
+      jobId,
       clusterId,
     }: {
       approved: boolean;
-      callId: string;
+      jobId: string;
       clusterId: string;
     }) => {
-      if (!clusterId || !callId) {
+      if (!clusterId || !jobId) {
         return;
       }
 
-      const result = await client.createCallApproval({
+      const result = await client.createJobApproval({
         body: {
           approved,
         },
@@ -245,7 +245,7 @@ export function Run({ clusterId, runId }: { clusterId: string; runId: string }) 
         },
         params: {
           clusterId,
-          callId,
+          jobId,
         },
       });
 
@@ -287,7 +287,7 @@ export function Run({ clusterId, runId }: { clusterId: string; runId: string }) 
             submitApproval={(approved: boolean) => {
               submitApproval({
                 approved,
-                callId: job.id,
+                jobId: job.id,
                 clusterId,
               });
             }}

--- a/control-plane/src/modules/contract.ts
+++ b/control-plane/src/modules/contract.ts
@@ -280,9 +280,9 @@ export const definition = {
   },
 
   // Job Endpoints
-  getCall: {
+  getJob: {
     method: "GET",
-    path: "/clusters/:clusterId/calls/:jobId",
+    path: "/clusters/:clusterId/jobs/:jobId",
     headers: z.object({ authorization: z.string() }),
     pathParams: z.object({
       clusterId: z.string(),
@@ -303,9 +303,9 @@ export const definition = {
       }),
     },
   },
-  createCall: {
+  createJob: {
     method: "POST",
-    path: "/clusters/:clusterId/calls",
+    path: "/clusters/:clusterId/jobs",
     query: z.object({
       waitTime: z.coerce
         .number()
@@ -332,9 +332,9 @@ export const definition = {
       }),
     },
   },
-  createCallResult: {
+  createJobResult: {
     method: "POST",
-    path: "/clusters/:clusterId/calls/:jobId/result",
+    path: "/clusters/:clusterId/jobs/:jobId/result",
     headers: z.object({
       authorization: z.string(),
       ...machineHeaders,
@@ -355,14 +355,14 @@ export const definition = {
       }),
     }),
   },
-  listCalls: {
+  listJobs: {
     method: "GET",
-    path: "/clusters/:clusterId/calls",
+    path: "/clusters/:clusterId/jobs",
     query: z.object({
       service: z.string(),
       status: z.enum(["pending", "running", "paused", "done", "failed"]).default("pending"),
       limit: z.coerce.number().min(1).max(20).default(10),
-      acknowledge: z.coerce.boolean().default(false).describe("Should calls be marked as running"),
+      acknowledge: z.coerce.boolean().default(false).describe("Should retrieved Jobs be marked as running"),
     }),
     pathParams: z.object({
       clusterId: z.string(),
@@ -388,9 +388,9 @@ export const definition = {
       ),
     },
   },
-  createCallApproval: {
+  createJobApproval: {
     method: "POST",
-    path: "/clusters/:clusterId/calls/:jobId/approval",
+    path: "/clusters/:clusterId/jobs/:jobId/approval",
     headers: z.object({
       authorization: z.string(),
     }),
@@ -408,9 +408,9 @@ export const definition = {
       approved: z.boolean(),
     }),
   },
-  createCallBlob: {
+  createJobBlob: {
     method: "POST",
-    path: "/clusters/:clusterId/calls/:jobId/blobs",
+    path: "/clusters/:clusterId/jobs/:jobId/blobs",
     headers: z.object({
       authorization: z.string(),
       "x-machine-id": z.string(),
@@ -763,7 +763,7 @@ export const definition = {
         .optional(),
       context: anyObject
         .optional()
-        .describe("Additional context to propogate to all calls in the run"),
+        .describe("Additional context to propogate to all Jobs in the Run"),
       reasoningTraces: z.boolean().default(true).optional().describe("Enable reasoning traces"),
       callSummarization: z
         .boolean()

--- a/control-plane/src/modules/contract.ts
+++ b/control-plane/src/modules/contract.ts
@@ -282,11 +282,11 @@ export const definition = {
   // Job Endpoints
   getCall: {
     method: "GET",
-    path: "/clusters/:clusterId/calls/:callId",
+    path: "/clusters/:clusterId/calls/:jobId",
     headers: z.object({ authorization: z.string() }),
     pathParams: z.object({
       clusterId: z.string(),
-      callId: z.string(),
+      jobId: z.string(),
     }),
     responses: {
       200: z.object({
@@ -334,14 +334,14 @@ export const definition = {
   },
   createCallResult: {
     method: "POST",
-    path: "/clusters/:clusterId/calls/:callId/result",
+    path: "/clusters/:clusterId/calls/:jobId/result",
     headers: z.object({
       authorization: z.string(),
       ...machineHeaders,
     }),
     pathParams: z.object({
       clusterId: z.string(),
-      callId: z.string(),
+      jobId: z.string(),
     }),
     responses: {
       204: z.undefined(),
@@ -390,13 +390,13 @@ export const definition = {
   },
   createCallApproval: {
     method: "POST",
-    path: "/clusters/:clusterId/calls/:callId/approval",
+    path: "/clusters/:clusterId/calls/:jobId/approval",
     headers: z.object({
       authorization: z.string(),
     }),
     pathParams: z.object({
       clusterId: z.string(),
-      callId: z.string(),
+      jobId: z.string(),
     }),
     responses: {
       204: z.undefined(),
@@ -410,7 +410,7 @@ export const definition = {
   },
   createCallBlob: {
     method: "POST",
-    path: "/clusters/:clusterId/calls/:callId/blobs",
+    path: "/clusters/:clusterId/calls/:jobId/blobs",
     headers: z.object({
       authorization: z.string(),
       "x-machine-id": z.string(),
@@ -421,7 +421,7 @@ export const definition = {
     }),
     pathParams: z.object({
       clusterId: z.string(),
-      callId: z.string(),
+      jobId: z.string(),
     }),
     responses: {
       201: z.object({

--- a/control-plane/src/modules/integrations/slack/index.ts
+++ b/control-plane/src/modules/integrations/slack/index.ts
@@ -138,14 +138,14 @@ export const handleNewRunMessage = async ({
 };
 
 export const handleApprovalRequest = async ({
-  callId,
+  jobId,
   runId,
   clusterId,
   service,
   targetFn,
   tags,
 }: {
-  callId: string;
+  jobId: string;
   runId: string;
   clusterId: string;
   service: string;
@@ -194,7 +194,7 @@ export const handleApprovalRequest = async ({
               type: "plain_text",
               text: "Approve",
             },
-            value: callId,
+            value: jobId,
             action_id: CALL_APPROVE_ACTION_ID,
           },
           {
@@ -203,7 +203,7 @@ export const handleApprovalRequest = async ({
               type: "plain_text",
               text: "Deny",
             },
-            value: callId,
+            value: jobId,
             action_id: CALL_DENY_ACTION_ID,
           },
         ],
@@ -624,7 +624,7 @@ const handleCallApprovalAction = async ({
 
   await submitApproval({
     approved,
-    callId: action.value,
+    jobId: action.value,
     clusterId: integration.cluster_id,
   });
 
@@ -632,7 +632,7 @@ const handleCallApprovalAction = async ({
     approved,
     channelId,
     messageTs,
-    callId: action.value,
+    jobId: action.value,
   });
 
   const text = `${approved ? "✅" : "❌"} Call \`${action.value}\` was ${approved ? "approved" : "denied"}`;

--- a/control-plane/src/modules/jobs/create-job.ts
+++ b/control-plane/src/modules/jobs/create-job.ts
@@ -266,7 +266,7 @@ const onAfterJobCreated = async ({
         MessageBody: JSON.stringify({
           clusterId: owner.clusterId,
           runId,
-          callId: jobId,
+          jobId,
           service,
           ...injectTraceContext(),
         }),

--- a/control-plane/src/modules/jobs/external.ts
+++ b/control-plane/src/modules/jobs/external.ts
@@ -29,7 +29,7 @@ export const stop = async () => {
 async function handleExternalCall(message: unknown) {
   const zodResult = baseMessageSchema
     .extend({
-      callId: z.string(),
+      jobId: z.string(),
       service: z.string(),
     })
     .safeParse(message);
@@ -55,7 +55,7 @@ async function handleExternalCall(message: unknown) {
   const [call, integrations] = await Promise.all([
     getJob({
       clusterId: zodResult.data.clusterId,
-      jobId: zodResult.data.callId,
+      jobId: zodResult.data.jobId,
     }),
     getIntegrations({
       clusterId: zodResult.data.clusterId,
@@ -63,9 +63,9 @@ async function handleExternalCall(message: unknown) {
   ]);
 
   if (!call) {
-    logger.error("Could not find call", {
+    logger.error("Could not find Job", {
       clusterId: zodResult.data.clusterId,
-      callId: zodResult.data.callId,
+      jobId: zodResult.data.jobId,
     });
     return;
   }

--- a/control-plane/src/modules/jobs/jobs.test.ts
+++ b/control-plane/src/modules/jobs/jobs.test.ts
@@ -4,7 +4,7 @@ import { upsertServiceDefinition } from "../service-definitions";
 import { createOwner } from "../test/util";
 import { createJob, pollJobs, getJob, requestApproval, submitApproval } from "./jobs";
 import { acknowledgeJob, persistJobResult } from "./job-results";
-import { selfHealCalls } from "./self-heal-jobs";
+import { selfHealJobs } from "./self-heal-jobs";
 import * as redis from "../redis";
 import { getClusterBackgroundRun } from "../runs";
 
@@ -105,7 +105,7 @@ describe("selfHealCalls", () => {
     await new Promise(resolve => setTimeout(resolve, 2000));
 
     // run the self heal job
-    const healedJobs = await selfHealCalls();
+    const healedJobs = await selfHealJobs();
 
     expect(healedJobs.stalledFailedByTimeout).toContain(createJobResult.id);
     expect(healedJobs.stalledRecovered).toContain(createJobResult.id);
@@ -151,7 +151,7 @@ describe("selfHealCalls", () => {
     expect(createJobResult.created).toBe(true);
 
     await requestApproval({
-      callId: createJobResult.id,
+      jobId: createJobResult.id,
       clusterId: owner.clusterId,
     });
 
@@ -159,7 +159,7 @@ describe("selfHealCalls", () => {
     await new Promise(resolve => setTimeout(resolve, 2000));
 
     // run the self heal job
-    const healedJobs = await selfHealCalls();
+    const healedJobs = await selfHealJobs();
 
     expect(healedJobs.stalledFailedByTimeout).not.toContain(createJobResult.id);
     expect(healedJobs.stalledRecovered).not.toContain(createJobResult.id);
@@ -215,7 +215,7 @@ describe("selfHealCalls", () => {
     await new Promise(resolve => setTimeout(resolve, 2000));
 
     // run the self heal job
-    const healedJobs = await selfHealCalls();
+    const healedJobs = await selfHealJobs();
 
     expect(healedJobs.stalledFailedByTimeout).toContain(createJobResult.id);
     expect(healedJobs.stalledRecovered).not.toContain(createJobResult.id);
@@ -464,7 +464,7 @@ describe("submitApproval", () => {
 
     await requestApproval({
       clusterId: owner.clusterId,
-      callId: result.id,
+      jobId: result.id,
     });
 
     const retreivedJob1 = await getJob({
@@ -476,7 +476,7 @@ describe("submitApproval", () => {
 
     await submitApproval({
       clusterId: owner.clusterId,
-      callId: retreivedJob1!.id,
+      jobId: retreivedJob1!.id,
       approved: true,
     });
 
@@ -492,7 +492,7 @@ describe("submitApproval", () => {
     // Re-submitting approval should be a no-op
     await submitApproval({
       clusterId: owner.clusterId,
-      callId: retreivedJob1!.id,
+      jobId: retreivedJob1!.id,
       approved: false,
     });
 
@@ -520,7 +520,7 @@ describe("submitApproval", () => {
 
     await requestApproval({
       clusterId: owner.clusterId,
-      callId: result.id,
+      jobId: result.id,
     });
 
     const retreivedJob1 = await getJob({
@@ -532,7 +532,7 @@ describe("submitApproval", () => {
 
     await submitApproval({
       clusterId: owner.clusterId,
-      callId: retreivedJob1!.id,
+      jobId: retreivedJob1!.id,
       approved: false,
     });
 
@@ -548,7 +548,7 @@ describe("submitApproval", () => {
     // Re-submitting approval should be a no-op
     await submitApproval({
       clusterId: owner.clusterId,
-      callId: retreivedJob1!.id,
+      jobId: retreivedJob1!.id,
       approved: true,
     });
 

--- a/control-plane/src/modules/jobs/router.ts
+++ b/control-plane/src/modules/jobs/router.ts
@@ -8,9 +8,9 @@ import { createBlob } from "../blobs";
 import { logger } from "../observability/logger";
 import { recordServicePoll } from "../service-definitions";
 import { getJob } from "../jobs/jobs";
-import { getClusterBackgroundRun, resumeRun } from "../runs";
+import { getClusterBackgroundRun } from "../runs";
 
-export const callsRouter = initServer().router(
+export const jobsRouter = initServer().router(
   {
     createCall: contract.createCall,
     createCallResult: contract.createCallResult,
@@ -76,7 +76,7 @@ export const callsRouter = initServer().router(
       };
     },
     createCallResult: async request => {
-      const { clusterId, callId } = request.params;
+      const { clusterId, jobId } = request.params;
       let { result, resultType } = request.body;
       const { meta } = request.body;
 
@@ -98,11 +98,11 @@ export const callsRouter = initServer().router(
 
         if (parsed.data.type === "approval") {
           logger.info("Requesting approval", {
-            callId,
+            jobId,
           });
 
           await jobs.requestApproval({
-            callId: callId,
+            jobId,
             clusterId,
           });
 
@@ -119,14 +119,14 @@ export const callsRouter = initServer().router(
         // Max result size 500kb
         const data = Buffer.from(JSON.stringify(result));
         if (Buffer.byteLength(data) > 500 * 1024) {
-          logger.info("Call result too large, persisting as blob", {
-            callId,
+          logger.info("Job result too large, persisting as blob", {
+            jobId,
           });
 
-          const call = await getJob({ clusterId, jobId: callId });
+          const job = await getJob({ clusterId, jobId });
 
-          if (!call) {
-            throw new NotFoundError("Call not found");
+          if (!job) {
+            throw new NotFoundError("Job not found");
           }
 
           await createBlob({
@@ -134,10 +134,10 @@ export const callsRouter = initServer().router(
             size: Buffer.byteLength(data),
             encoding: "base64",
             type: "application/json",
-            name: "Oversize call result",
+            name: "Oversize Job result",
             clusterId,
-            runId: call.runId ?? undefined,
-            jobId: callId ?? undefined,
+            runId: job.runId ?? undefined,
+            jobId: job.id ?? undefined,
           });
 
           result = {
@@ -168,7 +168,7 @@ export const callsRouter = initServer().router(
           result: packer.pack(result),
           resultType,
           functionExecutionTime: meta?.functionExecutionTime,
-          jobId: callId,
+          jobId,
           machineId,
         }),
       ]);
@@ -247,19 +247,19 @@ export const callsRouter = initServer().router(
       };
     },
     createCallBlob: async request => {
-      const { callId, clusterId } = request.params;
+      const { jobId, clusterId } = request.params;
       const body = request.body;
 
       const machine = request.request.getAuth().isMachine();
       machine.canAccess({ cluster: { clusterId } });
 
-      const call = await jobs.getJob({ clusterId, jobId: callId });
+      const job = await jobs.getJob({ clusterId, jobId });
 
-      if (!call) {
+      if (!job) {
         return {
           status: 404,
           body: {
-            message: "Call not found",
+            message: "Job not found",
           },
         };
       }
@@ -267,8 +267,8 @@ export const callsRouter = initServer().router(
       const blob = await createBlob({
         ...body,
         clusterId,
-        runId: call.runId ?? undefined,
-        jobId: callId ?? undefined,
+        runId: job.runId ?? undefined,
+        jobId: jobId ?? undefined,
       });
 
       return {
@@ -277,52 +277,52 @@ export const callsRouter = initServer().router(
       };
     },
     getCall: async request => {
-      const { clusterId, callId } = request.params;
+      const { clusterId, jobId } = request.params;
 
       const auth = request.request.getAuth();
       await auth.canAccess({ cluster: { clusterId } });
 
-      const call = await jobs.getJob({ clusterId, jobId: callId });
+      const job = await jobs.getJob({ clusterId, jobId });
 
-      if (!call) {
+      if (!job) {
         return {
           status: 404,
           body: {
-            message: "Call not found",
+            message: "Job not found",
           },
         };
       }
 
-      if (call.runId) {
+      if (job.runId) {
         await auth.canAccess({
-          run: { clusterId, runId: call.runId },
+          run: { clusterId, runId: job.runId },
         });
       }
 
       return {
         status: 200,
-        body: call,
+        body: job,
       };
     },
     createCallApproval: async request => {
-      const { clusterId, callId } = request.params;
+      const { clusterId, jobId } = request.params;
 
       const auth = request.request.getAuth();
       await auth.canManage({ cluster: { clusterId } });
 
-      const call = await jobs.getJob({ clusterId, jobId: callId });
+      const job = await jobs.getJob({ clusterId, jobId });
 
-      if (!call) {
+      if (!job) {
         return {
           status: 404,
           body: {
-            message: "Call not found",
+            message: "Job not found",
           },
         };
       }
 
       await jobs.submitApproval({
-        callId,
+        jobId,
         clusterId,
         approved: request.body.approved,
       });

--- a/control-plane/src/modules/jobs/router.ts
+++ b/control-plane/src/modules/jobs/router.ts
@@ -12,15 +12,15 @@ import { getClusterBackgroundRun } from "../runs";
 
 export const jobsRouter = initServer().router(
   {
-    createCall: contract.createCall,
-    createCallResult: contract.createCallResult,
-    listCalls: contract.listCalls,
-    createCallBlob: contract.createCallBlob,
-    getCall: contract.getCall,
-    createCallApproval: contract.createCallApproval,
+    createJob: contract.createJob,
+    createJobResult: contract.createJobResult,
+    listJobs: contract.listJobs,
+    createJobBlob: contract.createJobBlob,
+    getJob: contract.getJob,
+    createJobApproval: contract.createJobApproval,
   },
   {
-    createCall: async request => {
+    createJob: async request => {
       const { clusterId } = request.params;
 
       const auth = request.request.getAuth();
@@ -75,7 +75,7 @@ export const jobsRouter = initServer().router(
         },
       };
     },
-    createCallResult: async request => {
+    createJobResult: async request => {
       const { clusterId, jobId } = request.params;
       let { result, resultType } = request.body;
       const { meta } = request.body;
@@ -178,7 +178,7 @@ export const jobsRouter = initServer().router(
         body: undefined,
       };
     },
-    listCalls: async request => {
+    listJobs: async request => {
       const { clusterId } = request.params;
       const { service, limit, acknowledge, status } = request.query;
 
@@ -246,7 +246,7 @@ export const jobsRouter = initServer().router(
         })),
       };
     },
-    createCallBlob: async request => {
+    createJobBlob: async request => {
       const { jobId, clusterId } = request.params;
       const body = request.body;
 
@@ -276,7 +276,7 @@ export const jobsRouter = initServer().router(
         body: blob,
       };
     },
-    getCall: async request => {
+    getJob: async request => {
       const { clusterId, jobId } = request.params;
 
       const auth = request.request.getAuth();
@@ -304,7 +304,7 @@ export const jobsRouter = initServer().router(
         body: job,
       };
     },
-    createCallApproval: async request => {
+    createJobApproval: async request => {
       const { clusterId, jobId } = request.params;
 
       const auth = request.request.getAuth();

--- a/control-plane/src/modules/jobs/self-heal-jobs.ts
+++ b/control-plane/src/modules/jobs/self-heal-jobs.ts
@@ -4,8 +4,8 @@ import * as events from "../observability/events";
 import { logger } from "../observability/logger";
 import { resumeRun } from "../runs";
 
-export async function selfHealCalls() {
-  logger.debug("Running Self-healing job");
+export async function selfHealJobs() {
+  logger.debug("Running Job Self-healing");
 
   // Jobs are failed if they are running and have timed out
   const stalledByTimeout = await data.db

--- a/control-plane/src/modules/router.ts
+++ b/control-plane/src/modules/router.ts
@@ -35,7 +35,7 @@ import {
   getKnowledgeArtifact,
   getAllKnowledgeArtifacts,
 } from "./knowledge/knowledgebase";
-import { callsRouter } from "./calls/router";
+import { jobsRouter } from "./jobs/router";
 import { buildModel } from "./models";
 import { getServiceDefinitions } from "./service-definitions";
 import { integrationsRouter } from "./integrations/router";
@@ -47,7 +47,7 @@ export const router = initServer().router(contract, {
   ...machineRouter.routes,
   ...runsRouter.routes,
   ...authRouter.routes,
-  ...callsRouter.routes,
+  ...jobsRouter.routes,
   ...integrationsRouter.routes,
   live: async () => {
     await data.isAlive();

--- a/control-plane/src/modules/runs/notify.ts
+++ b/control-plane/src/modules/runs/notify.ts
@@ -10,20 +10,20 @@ import * as email from "../email";
 
 
 export const notifyApprovalRequest = async ({
-  callId,
+  jobId,
   clusterId,
   runId,
   service,
   targetFn,
 }: {
-  callId: string;
+  jobId: string;
   clusterId: string;
   runId: string;
   service: string;
   targetFn: string;
 }) => {
   const tags = await getRunTags({ clusterId, runId });
-  await slack.handleApprovalRequest({ callId, clusterId, runId, service, targetFn, tags });
+  await slack.handleApprovalRequest({ jobId, clusterId, runId, service, targetFn, tags });
 };
 
 export const notifyNewMessage = async ({

--- a/sdk-node/src/contract.ts
+++ b/sdk-node/src/contract.ts
@@ -280,13 +280,13 @@ export const definition = {
   },
 
   // Job Endpoints
-  getCall: {
+  getJob: {
     method: "GET",
-    path: "/clusters/:clusterId/calls/:callId",
+    path: "/clusters/:clusterId/jobs/:jobId",
     headers: z.object({ authorization: z.string() }),
     pathParams: z.object({
       clusterId: z.string(),
-      callId: z.string(),
+      jobId: z.string(),
     }),
     responses: {
       200: z.object({
@@ -303,9 +303,9 @@ export const definition = {
       }),
     },
   },
-  createCall: {
+  createJob: {
     method: "POST",
-    path: "/clusters/:clusterId/calls",
+    path: "/clusters/:clusterId/jobs",
     query: z.object({
       waitTime: z.coerce
         .number()
@@ -332,16 +332,16 @@ export const definition = {
       }),
     },
   },
-  createCallResult: {
+  createJobResult: {
     method: "POST",
-    path: "/clusters/:clusterId/calls/:callId/result",
+    path: "/clusters/:clusterId/jobs/:jobId/result",
     headers: z.object({
       authorization: z.string(),
       ...machineHeaders,
     }),
     pathParams: z.object({
       clusterId: z.string(),
-      callId: z.string(),
+      jobId: z.string(),
     }),
     responses: {
       204: z.undefined(),
@@ -355,14 +355,14 @@ export const definition = {
       }),
     }),
   },
-  listCalls: {
+  listJobs: {
     method: "GET",
-    path: "/clusters/:clusterId/calls",
+    path: "/clusters/:clusterId/jobs",
     query: z.object({
       service: z.string(),
       status: z.enum(["pending", "running", "paused", "done", "failed"]).default("pending"),
       limit: z.coerce.number().min(1).max(20).default(10),
-      acknowledge: z.coerce.boolean().default(false).describe("Should calls be marked as running"),
+      acknowledge: z.coerce.boolean().default(false).describe("Should retrieved Jobs be marked as running"),
     }),
     pathParams: z.object({
       clusterId: z.string(),
@@ -388,15 +388,15 @@ export const definition = {
       ),
     },
   },
-  createCallApproval: {
+  createJobApproval: {
     method: "POST",
-    path: "/clusters/:clusterId/calls/:callId/approval",
+    path: "/clusters/:clusterId/jobs/:jobId/approval",
     headers: z.object({
       authorization: z.string(),
     }),
     pathParams: z.object({
       clusterId: z.string(),
-      callId: z.string(),
+      jobId: z.string(),
     }),
     responses: {
       204: z.undefined(),
@@ -408,9 +408,9 @@ export const definition = {
       approved: z.boolean(),
     }),
   },
-  createCallBlob: {
+  createJobBlob: {
     method: "POST",
-    path: "/clusters/:clusterId/calls/:callId/blobs",
+    path: "/clusters/:clusterId/jobs/:jobId/blobs",
     headers: z.object({
       authorization: z.string(),
       "x-machine-id": z.string(),
@@ -421,7 +421,7 @@ export const definition = {
     }),
     pathParams: z.object({
       clusterId: z.string(),
-      callId: z.string(),
+      jobId: z.string(),
     }),
     responses: {
       201: z.object({
@@ -763,7 +763,7 @@ export const definition = {
         .optional(),
       context: anyObject
         .optional()
-        .describe("Additional context to propogate to all calls in the run"),
+        .describe("Additional context to propogate to all Jobs in the Run"),
       reasoningTraces: z.boolean().default(true).optional().describe("Enable reasoning traces"),
       callSummarization: z
         .boolean()

--- a/sdk-node/src/contract.ts
+++ b/sdk-node/src/contract.ts
@@ -280,13 +280,13 @@ export const definition = {
   },
 
   // Job Endpoints
-  getJob: {
+  getCall: {
     method: "GET",
-    path: "/clusters/:clusterId/jobs/:jobId",
+    path: "/clusters/:clusterId/calls/:callId",
     headers: z.object({ authorization: z.string() }),
     pathParams: z.object({
       clusterId: z.string(),
-      jobId: z.string(),
+      callId: z.string(),
     }),
     responses: {
       200: z.object({
@@ -303,9 +303,9 @@ export const definition = {
       }),
     },
   },
-  createJob: {
+  createCall: {
     method: "POST",
-    path: "/clusters/:clusterId/jobs",
+    path: "/clusters/:clusterId/calls",
     query: z.object({
       waitTime: z.coerce
         .number()
@@ -332,16 +332,16 @@ export const definition = {
       }),
     },
   },
-  createJobResult: {
+  createCallResult: {
     method: "POST",
-    path: "/clusters/:clusterId/jobs/:jobId/result",
+    path: "/clusters/:clusterId/calls/:callId/result",
     headers: z.object({
       authorization: z.string(),
       ...machineHeaders,
     }),
     pathParams: z.object({
       clusterId: z.string(),
-      jobId: z.string(),
+      callId: z.string(),
     }),
     responses: {
       204: z.undefined(),
@@ -355,14 +355,14 @@ export const definition = {
       }),
     }),
   },
-  listJobs: {
+  listCalls: {
     method: "GET",
-    path: "/clusters/:clusterId/jobs",
+    path: "/clusters/:clusterId/calls",
     query: z.object({
       service: z.string(),
       status: z.enum(["pending", "running", "paused", "done", "failed"]).default("pending"),
       limit: z.coerce.number().min(1).max(20).default(10),
-      acknowledge: z.coerce.boolean().default(false).describe("Should retrieved Jobs be marked as running"),
+      acknowledge: z.coerce.boolean().default(false).describe("Should calls be marked as running"),
     }),
     pathParams: z.object({
       clusterId: z.string(),
@@ -388,15 +388,15 @@ export const definition = {
       ),
     },
   },
-  createJobApproval: {
+  createCallApproval: {
     method: "POST",
-    path: "/clusters/:clusterId/jobs/:jobId/approval",
+    path: "/clusters/:clusterId/calls/:callId/approval",
     headers: z.object({
       authorization: z.string(),
     }),
     pathParams: z.object({
       clusterId: z.string(),
-      jobId: z.string(),
+      callId: z.string(),
     }),
     responses: {
       204: z.undefined(),
@@ -408,9 +408,9 @@ export const definition = {
       approved: z.boolean(),
     }),
   },
-  createJobBlob: {
+  createCallBlob: {
     method: "POST",
-    path: "/clusters/:clusterId/jobs/:jobId/blobs",
+    path: "/clusters/:clusterId/calls/:callId/blobs",
     headers: z.object({
       authorization: z.string(),
       "x-machine-id": z.string(),
@@ -421,7 +421,7 @@ export const definition = {
     }),
     pathParams: z.object({
       clusterId: z.string(),
-      jobId: z.string(),
+      callId: z.string(),
     }),
     responses: {
       201: z.object({
@@ -763,7 +763,7 @@ export const definition = {
         .optional(),
       context: anyObject
         .optional()
-        .describe("Additional context to propogate to all Jobs in the Run"),
+        .describe("Additional context to propogate to all calls in the run"),
       reasoningTraces: z.boolean().default(true).optional().describe("Enable reasoning traces"),
       callSummarization: z
         .boolean()


### PR DESCRIPTION
### **User description**
- Rename `/calls` -> `/jobs`
- Replace internal usage of `callId` with -> `jobId`

[This is a non-breaking change to the API as requests to `/calls` are rewritten to `/jobs` with logging.](https://github.com/inferablehq/inferable/pull/489/files#diff-8e4e22a02f3b97d06c0962b793887b30dbe788682975acdda1b012e14d42bce3R31)


___

### **PR Type**
enhancement, bug fix


___

### **Description**
- Rename `call` terminology to `job` across the codebase.

- Update API endpoints and internal references for consistency.

- Add request rewrite logic to maintain backward compatibility.

- Adjust tests and documentation to reflect the changes.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>13 files</summary><table>
<tr>
  <td><strong>contract.ts</strong><dd><code>Update API contract to rename `call` to `job`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/489/files#diff-f9f903da20c390025ebd16471b02a8c32f82a40e10f6519a035fcfc8a4df4a4c">+18/-18</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>function-call.tsx</strong><dd><code>Replace `call` references with `job` in chat component</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/489/files#diff-73d9eaa4304dc3afaba8943c0685c4150de9471365d789059d58ff6c806c173b">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>workflow.tsx</strong><dd><code>Update workflow logic to use `job` terminology</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/489/files#diff-3869bd7c46b85e34e1b64ec4f754b5872b864e1fa5b62051fb65f2af161b9530">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>contract.ts</strong><dd><code>Update contract module to reflect `job` renaming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/489/files#diff-b5950839f91929a72fdc1a19dbd99f3c7db3032893deb18743fc93deff2e34bc">+18/-18</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Adjust Slack integration to use `job` terminology</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/489/files#diff-371db4e2ab9c97fb66d167e085aad6f537472811427c427967ef527f85dfa483">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>toolhouse.ts</strong><dd><code>Update Toolhouse integration to handle `job` references</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/489/files#diff-05cec4878eadd589571e42691e00f1c38d8e5325bdbd237ecfeec7a1c4685de5">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>create-job.ts</strong><dd><code>Update job creation logic to align with new terminology</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/489/files#diff-6e53c4b559a47d5d48b0656dec19810a4d9c004845a5883978c6078db230ec67">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>external.ts</strong><dd><code>Adjust external job handling to use `job` terminology</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/489/files#diff-d06e55e27d4bdcf4e1d6ca738a456b0a95c47a588f3c4655fa981067a4ed3b9a">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>jobs.ts</strong><dd><code>Rename `call` references to `job` in job module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/489/files#diff-ae1e9fb36ce0c15bb920258e18509fa15663b645da87a2d6a76ead7d7baa2edd">+10/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>router.ts</strong><dd><code>Update job router to replace `call` with `job`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/489/files#diff-3099df9ddb47b59aec870ea7bfcc20edb15fa11a56858d1193d29ebfdc6c7b0d">+44/-44</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>self-heal-jobs.ts</strong><dd><code>Rename self-healing logic from `call` to `job`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/489/files#diff-2e0dad02349a2704f54b192ebaab3bb7a24a82da90bb6dff9274c5f6a9c07655">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>router.ts</strong><dd><code>Replace `callsRouter` with `jobsRouter` in main router</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/489/files#diff-8ae44be4c7b96ed5ba871dae265ba5e854ab9c80720d80f8f6412ea560fe200a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>notify.ts</strong><dd><code>Update notification logic to use `job` terminology</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/489/files#diff-a451a6d3a81de3bec975b66b08a99fb85f7e01b1d57341eedb092058b7126698">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>bootstrap.ts</strong><dd><code>Add request rewrite for backward compatibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/489/files#diff-8e4e22a02f3b97d06c0962b793887b30dbe788682975acdda1b012e14d42bce3">+23/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>jobs.test.ts</strong><dd><code>Update tests to reflect `call` to `job` renaming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/inferablehq/inferable/pull/489/files#diff-7d9609fcd33082c6bbd3a208e325ec3f0c8a57a28e8cd351dc81199a1f5cd1ff">+11/-11</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information