### PR TITLE
feat: Replace calls -> jobs in node SDK

### DIFF
--- a/sdk-node/package.json
+++ b/sdk-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inferable",
-  "version": "0.30.67",
+  "version": "0.30.68",
   "description": "Javascript SDK for inferable.ai",
   "main": "bin/index.js",
   "scripts": {

--- a/sdk-node/src/Inferable.test.ts
+++ b/sdk-node/src/Inferable.test.ts
@@ -138,7 +138,7 @@ describe("Functions", () => {
 
     const results = await Promise.all(
       Array.from({ length: 10 }).map(async (_, i) => {
-        return client.createCall({
+        return client.createJob({
           query: {
             waitTime: 20,
           },
@@ -192,7 +192,7 @@ describe("Functions", () => {
     const service = testService();
     await service.start();
 
-    const result = await client.createCall({
+    const result = await client.createJob({
       query: {
         waitTime: 20,
       },

--- a/sdk-node/src/contract.ts
+++ b/sdk-node/src/contract.ts
@@ -280,13 +280,13 @@ export const definition = {
   },
 
   // Job Endpoints
-  getCall: {
+  getJob: {
     method: "GET",
-    path: "/clusters/:clusterId/calls/:callId",
+    path: "/clusters/:clusterId/jobs/:jobId",
     headers: z.object({ authorization: z.string() }),
     pathParams: z.object({
       clusterId: z.string(),
-      callId: z.string(),
+      jobId: z.string(),
     }),
     responses: {
       200: z.object({
@@ -303,9 +303,9 @@ export const definition = {
       }),
     },
   },
-  createCall: {
+  createJob: {
     method: "POST",
-    path: "/clusters/:clusterId/calls",
+    path: "/clusters/:clusterId/jobs",
     query: z.object({
       waitTime: z.coerce
         .number()
@@ -332,16 +332,16 @@ export const definition = {
       }),
     },
   },
-  createCallResult: {
+  createJobResult: {
     method: "POST",
-    path: "/clusters/:clusterId/calls/:callId/result",
+    path: "/clusters/:clusterId/jobs/:jobId/result",
     headers: z.object({
       authorization: z.string(),
       ...machineHeaders,
     }),
     pathParams: z.object({
       clusterId: z.string(),
-      callId: z.string(),
+      jobId: z.string(),
     }),
     responses: {
       204: z.undefined(),
@@ -355,14 +355,14 @@ export const definition = {
       }),
     }),
   },
-  listCalls: {
+  listJobs: {
     method: "GET",
-    path: "/clusters/:clusterId/calls",
+    path: "/clusters/:clusterId/jobs",
     query: z.object({
       service: z.string(),
       status: z.enum(["pending", "running", "paused", "done", "failed"]).default("pending"),
       limit: z.coerce.number().min(1).max(20).default(10),
-      acknowledge: z.coerce.boolean().default(false).describe("Should calls be marked as running"),
+      acknowledge: z.coerce.boolean().default(false).describe("Should retrieved Jobs be marked as running"),
     }),
     pathParams: z.object({
       clusterId: z.string(),
@@ -388,15 +388,15 @@ export const definition = {
       ),
     },
   },
-  createCallApproval: {
+  createJobApproval: {
     method: "POST",
-    path: "/clusters/:clusterId/calls/:callId/approval",
+    path: "/clusters/:clusterId/jobs/:jobId/approval",
     headers: z.object({
       authorization: z.string(),
     }),
     pathParams: z.object({
       clusterId: z.string(),
-      callId: z.string(),
+      jobId: z.string(),
     }),
     responses: {
       204: z.undefined(),
@@ -408,9 +408,9 @@ export const definition = {
       approved: z.boolean(),
     }),
   },
-  createCallBlob: {
+  createJobBlob: {
     method: "POST",
-    path: "/clusters/:clusterId/calls/:callId/blobs",
+    path: "/clusters/:clusterId/jobs/:jobId/blobs",
     headers: z.object({
       authorization: z.string(),
       "x-machine-id": z.string(),
@@ -421,7 +421,7 @@ export const definition = {
     }),
     pathParams: z.object({
       clusterId: z.string(),
-      callId: z.string(),
+      jobId: z.string(),
     }),
     responses: {
       201: z.object({
@@ -763,7 +763,7 @@ export const definition = {
         .optional(),
       context: anyObject
         .optional()
-        .describe("Additional context to propogate to all calls in the run"),
+        .describe("Additional context to propogate to all Jobs in the Run"),
       reasoningTraces: z.boolean().default(true).optional().describe("Enable reasoning traces"),
       callSummarization: z
         .boolean()

--- a/sdk-node/src/service.ts
+++ b/sdk-node/src/service.ts
@@ -94,7 +94,7 @@ export class Service {
       throw new Error("Failed to poll. Could not find clusterId");
     }
 
-    const pollResult = await this.client.listCalls({
+    const pollResult = await this.client.listJobs({
       params: {
         clusterId: this.clusterId,
       },
@@ -166,7 +166,7 @@ export class Service {
       const contentAndBlobs = extractBlobs(result.content);
 
       const persistResult = this.client
-        .createCallResult({
+        .createJobResult({
           headers: {
             "x-sentinel-unmask-keys": "resultType,functionExecutionTime",
           },
@@ -178,7 +178,7 @@ export class Service {
             },
           },
           params: {
-            callId: call.id,
+            jobId: call.id,
             clusterId: this.clusterId!,
           },
         })
@@ -195,12 +195,12 @@ export class Service {
 
       const persistBlobs = contentAndBlobs.blobs.map((blob) =>
         this.client
-          .createCallBlob({
+          .createJobBlob({
             headers: {
               "x-sentinel-no-mask": "1",
             },
             params: {
-              callId: call.id,
+              jobId: call.id,
               clusterId: this.clusterId!,
             },
             body: blob,

--- a/sdk-node/src/tests/errors/errors.test.ts
+++ b/sdk-node/src/tests/errors/errors.test.ts
@@ -13,7 +13,7 @@ describe("Errors", () => {
   });
 
   it("should get the normal error", async () => {
-    const result = await client.createCall({
+    const result = await client.createJob({
       query: {
         waitTime: 20,
       },
@@ -43,7 +43,7 @@ describe("Errors", () => {
   });
 
   it("should get the custom error", async () => {
-    const result = await client.createCall({
+    const result = await client.createJob({
       query: {
         waitTime: 20,
       },

--- a/sdk-node/src/tests/utility/caching.test.ts
+++ b/sdk-node/src/tests/utility/caching.test.ts
@@ -16,7 +16,7 @@ describe("Caching", () => {
   it("should get the cached results when possible", async () => {
     const productId = Math.random().toString();
 
-    const result1 = await client.createCall({
+    const result1 = await client.createJob({
       query: {
         waitTime: 20,
       },
@@ -30,7 +30,7 @@ describe("Caching", () => {
       },
     });
 
-    const result2 = await client.createCall({
+    const result2 = await client.createJob({
       query: {
         waitTime: 20,
       },
@@ -62,7 +62,7 @@ describe("Caching", () => {
   it("should respect cache ttl", async () => {
     const productId = Math.random().toString();
 
-    const result1 = await client.createCall({
+    const result1 = await client.createJob({
       query: {
         waitTime: 20,
       },
@@ -78,7 +78,7 @@ describe("Caching", () => {
 
     await new Promise((resolve) => setTimeout(resolve, 2000)); // wait for cache to expire
 
-    const result2 = await client.createCall({
+    const result2 = await client.createJob({
       query: {
         waitTime: 20,
       },

--- a/sdk-node/src/tests/utility/retry.test.ts
+++ b/sdk-node/src/tests/utility/retry.test.ts
@@ -16,7 +16,7 @@ describe("retrying", () => {
   it("should not retry a function when attempts is 1", async () => {
     const productId = Math.random().toString();
 
-    const result = await client.createCall({
+    const result = await client.createJob({
       query: {
         waitTime: 20,
       },
@@ -43,7 +43,7 @@ describe("retrying", () => {
   it("should be able to retry a function", async () => {
     const productId = Math.random().toString();
 
-    const result = await client.createCall({
+    const result = await client.createJob({
       query: {
         waitTime: 20,
       },


### PR DESCRIPTION
### **User description**
Follow on from #489


___

### **PR Type**
Enhancement


___

### **Description**
- Replaced all references to "calls" with "jobs" in the Node SDK.

- Updated endpoint paths and parameter names to reflect the change.

- Adjusted descriptions and comments to align with the terminology update.

- Modified service logic to use "jobs" instead of "calls".


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>contract.ts</strong><dd><code>Refactor "calls" to "jobs" in contract definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sdk-node/src/contract.ts

<li>Renamed all "calls" references to "jobs".<br> <li> Updated endpoint paths and parameter names.<br> <li> Adjusted descriptions and comments for consistency.<br> <li> Modified schemas and response structures to use "jobs".


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/491/files#diff-471c07a721c8f0439fb7b473243c039c94a26a554588aced362d87b771fd9cdd">+18/-18</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>service.ts</strong><dd><code>Update service logic to use "jobs"</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sdk-node/src/service.ts

<li>Replaced "listCalls" with "listJobs" in polling logic.<br> <li> Updated "createCallResult" to "createJobResult".<br> <li> Refactored "createCallBlob" to "createJobBlob".<br> <li> Adjusted parameter names and logic to use "jobs".


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/491/files#diff-ae798733d76da15cc3f9fa2719768b3c03807f08cc6a648d6da1f92ac72c0e49">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information