### PR TITLE
chore: Add tests around Slack cleanup logic

### DIFF
--- a/control-plane/src/modules/integrations/slack/index.test.ts
+++ b/control-plane/src/modules/integrations/slack/index.test.ts
@@ -1,0 +1,74 @@
+import { cleanupConflictingIntegrations } from ".";
+import { createOwner } from "../../test/util";
+import { getIntegrations, upsertIntegrations } from "../integrations";
+import { nango } from "../nango";
+
+jest.mock("../nango", () => ({
+  nango: {
+    deleteConnection: jest.fn(),
+  },
+}))
+
+
+describe("cleanupConflictingIntegrations", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  })
+
+  it("should cleanup duplicate integrations for team ID", async () => {
+    const owner1 = await createOwner();
+    const owner2 = await createOwner();
+
+    await upsertIntegrations({
+      clusterId: owner1.clusterId,
+      config: {
+        slack: {
+          teamId: "team1",
+          nangoConnectionId: "connection1",
+          botUserId: "bot1",
+        }
+      }
+    })
+
+    await cleanupConflictingIntegrations(owner2.clusterId, {
+      slack: {
+        teamId: "team1",
+        nangoConnectionId: "connection1",
+        botUserId: "bot1",
+      }
+    })
+
+    const owner1Integrations = await getIntegrations({ clusterId: owner1.clusterId });
+    expect(owner1Integrations.slack).toBeNull();
+    expect((nango as any).deleteConnection).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not cleanup integrations for other teams", async () => {
+    const owner1 = await createOwner();
+    const owner2 = await createOwner();
+
+    await upsertIntegrations({
+      clusterId: owner1.clusterId,
+      config: {
+        slack: {
+          teamId: "team1",
+          nangoConnectionId: "connection1",
+          botUserId: "bot1",
+        }
+      }
+    })
+
+
+    await cleanupConflictingIntegrations(owner2.clusterId, {
+      slack: {
+        teamId: "team2",
+        nangoConnectionId: "connection2",
+        botUserId: "bot2",
+      }
+    })
+
+    const owner1Integrations = await getIntegrations({ clusterId: owner1.clusterId });
+    expect(owner1Integrations.slack).not.toBeNull();
+    expect((nango as any).deleteConnection).not.toHaveBeenCalled();
+  });
+});

--- a/control-plane/src/modules/integrations/slack/index.ts
+++ b/control-plane/src/modules/integrations/slack/index.ts
@@ -426,7 +426,7 @@ const getAccessToken = async (connectionId: string) => {
   return result;
 };
 
-const cleanupConflictingIntegrations = async (
+export const cleanupConflictingIntegrations = async (
   clusterId: string,
   config: z.infer<typeof integrationSchema>
 ) => {
@@ -445,16 +445,9 @@ const cleanupConflictingIntegrations = async (
     );
 
   if (conflicts.length) {
-    logger.info("Removed conflicting Slack integrations", {
+    logger.info("Removing conflicting Slack integrations", {
       conflicts: conflicts.map(conflict => conflict.cluster_id),
     });
-
-    // Cleanup Slack integrations from DB
-    await db
-      .delete(integrations)
-      .where(
-        and(sql`slack->>'teamId' = ${config.slack.teamId}`, ne(integrations.cluster_id, clusterId))
-      );
 
     // Cleanup Nango connections
     await Promise.allSettled(
@@ -464,6 +457,13 @@ const cleanupConflictingIntegrations = async (
         }
       })
     );
+
+    // Cleanup Slack integrations from DB
+    await db
+      .delete(integrations)
+      .where(
+        and(sql`slack->>'teamId' = ${config.slack.teamId}`, ne(integrations.cluster_id, clusterId))
+      );
   }
 };
 


### PR DESCRIPTION
### **PR Type**
Tests, Enhancement


___

### **Description**
- Added unit tests for Slack integration cleanup logic.

- Exported `cleanupConflictingIntegrations` for external usage.

- Adjusted logging message for better clarity.

- Reordered database cleanup logic for consistency.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.test.ts</strong><dd><code>Add unit tests for Slack cleanup logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

control-plane/src/modules/integrations/slack/index.test.ts

<li>Added unit tests for <code>cleanupConflictingIntegrations</code>.<br> <li> Mocked <code>nango</code> module for testing.<br> <li> Tested duplicate and non-duplicate Slack integration scenarios.


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/513/files#diff-5dd0986ea1ebf9dfdc3a0d2e2d35927408e991cc50912ecf2003033970415a81">+74/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Enhance and export Slack cleanup function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

control-plane/src/modules/integrations/slack/index.ts

<li>Exported <code>cleanupConflictingIntegrations</code> function.<br> <li> Adjusted logging message for clarity.<br> <li> Reordered database cleanup logic after Nango cleanup.


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/513/files#diff-371db4e2ab9c97fb66d167e085aad6f537472811427c427967ef527f85dfa483">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information