### PR TITLE
fix: Re-add agent tab in Runs page

### DIFF
--- a/app/components/chat/prompt-textarea.tsx
+++ b/app/components/chat/prompt-textarea.tsx
@@ -16,24 +16,14 @@ import {
   Cog,
   PlusCircleIcon,
   Settings2Icon,
-  Zap,
 } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "../ui/button";
 import Commands from "./sdk-commands";
 import { isFeatureEnabled } from "@/lib/features";
-import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "../ui/select";
 import toast from "react-hot-toast";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
-import { Badge } from "../ui/badge";
 import { useClusterState } from "../useClusterState";
 
 export type RunOptions = {
@@ -117,6 +107,28 @@ export function PromptTextarea({ clusterId }: { clusterId: string }) {
   const [selectedAgentId, setSelectedAgentId] = useState<string | undefined>(undefined);
 
   const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const fetchAgents = async () => {
+      const token = await getToken();
+      if (!token) return;
+      const res = await client.listAgents({
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+        params: {
+          clusterId,
+        },
+      });
+      if (res.status !== 200) {
+        createErrorToast(res, "Error fetching agents");
+        return;
+      }
+
+      setAgents(res.body);
+    };
+    fetchAgents();
+  }, [getToken]);
 
   useEffect(() => {
     if (agents) {


### PR DESCRIPTION
### **User description**
Re-implement agent fetch in `/runs` page.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Re-added functionality to fetch agents in the `/runs` page.

- Implemented a new `fetchAgents` function to retrieve agent data.

- Removed unused imports and cleaned up the code structure.

- Improved error handling for agent fetching with `createErrorToast`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>prompt-textarea.tsx</strong><dd><code>Re-implemented agent fetching and cleaned up code</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/components/chat/prompt-textarea.tsx

<li>Added a <code>fetchAgents</code> function to retrieve agent data.<br> <li> Removed unused imports like <code>Zap</code>, <code>Badge</code>, and <code>Select</code> components.<br> <li> Improved error handling with <code>createErrorToast</code> for agent fetching.<br> <li> Cleaned up state management for <code>selectedAgentId</code> and <code>agents</code>.


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/514/files#diff-0804a76578a0fc8aae7540609d142f71d3177149430173d60e44fecf8f907224">+22/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information