### PR TITLE
feat: Make Toolhouse permanent

### DIFF
--- a/control-plane/src/modules/integrations/toolhouse.ts
+++ b/control-plane/src/modules/integrations/toolhouse.ts
@@ -9,7 +9,7 @@ import * as data from "../data";
 import { acknowledgeJob, getJob, persistJobResult } from "../jobs/jobs";
 import { logger } from "../observability/logger";
 import { packer } from "../packer";
-import { upsertServiceDefinition } from "../service-definitions";
+import { deleteServiceDefinition, upsertServiceDefinition } from "../service-definitions";
 import { InstallableIntegration } from "./types";
 import { toolhouseIntegration } from "./constants";
 
@@ -161,6 +161,7 @@ const syncToolHouseService = async ({
 
   await upsertServiceDefinition({
     service: toolhouseIntegration,
+    type: "permanent",
     definition: {
       name: toolhouseIntegration,
       functions: tools.map(tool => {
@@ -229,8 +230,13 @@ export const toolhouse: InstallableIntegration = {
       apiKey: config.toolhouse?.apiKey,
     });
   },
-  onDeactivate: async (clusterId: string, config: z.infer<typeof integrationSchema>) => {
-    // TODO: (good-first-issue) Delete the service definition
+  onDeactivate: async (clusterId: string, _: z.infer<typeof integrationSchema>) => {
+    await deleteServiceDefinition({
+      service: toolhouseIntegration,
+      owner: {
+        clusterId,
+      },
+    })
   },
   handleCall,
 };


### PR DESCRIPTION
### **User description**
Now that the service timeout (#518 ) has been reduced to < the tollhouse sync job, make the toolhouse.ai integration's service `type=permanent` to avoid cleanup.

Also implement the integration's `onDeactivate` handler to allow service cleanup.


___

### **PR Type**
Enhancement


___

### **Description**
- Made the `toolhouse` service type permanent for persistent integration.

- Implemented `onDeactivate` handler to clean up service definitions.

- Updated service definition logic to include deletion functionality.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>toolhouse.ts</strong><dd><code>Update ToolHouse integration for permanence and cleanup</code>&nbsp; &nbsp; </dd></summary>
<hr>

control-plane/src/modules/integrations/toolhouse.ts

<li>Changed <code>toolhouse</code> service type to <code>permanent</code>.<br> <li> Added <code>onDeactivate</code> handler to delete service definitions.<br> <li> Included <code>deleteServiceDefinition</code> import for cleanup functionality.


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/519/files#diff-05cec4878eadd589571e42691e00f1c38d8e5325bdbd237ecfeec7a1c4685de5">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information