### PR TITLE
fix: Remove service poll throttle

### DIFF
--- a/control-plane/src/modules/service-definitions.ts
+++ b/control-plane/src/modules/service-definitions.ts
@@ -64,27 +64,24 @@ export async function recordServicePoll({
   clusterId,
   service,
 }: {
-  clusterId: string;
-  service: string;
-}) {
-  // As we call this on each poll, limit the number of updates that reach the database
-  return withThrottle(`clusters:${clusterId}:services:${service}:throttle`, 60, async () => {
-    const result = await data.db
-      .update(data.services)
-      .set({
-        timestamp: new Date(),
-      })
-      .where(and(eq(data.services.cluster_id, clusterId), eq(data.services.service, service)))
-      .returning({
-        service: data.services.service,
-      });
+    clusterId: string;
+    service: string;
+  }) {
+  const result = await data.db
+    .update(data.services)
+    .set({
+      timestamp: new Date(),
+    })
+    .where(and(eq(data.services.cluster_id, clusterId), eq(data.services.service, service)))
+    .returning({
+      service: data.services.service,
+    });
 
-    if (result.length === 0) {
-      return false;
-    }
+  if (result.length === 0) {
+    return false;
+  }
 
-    return true;
-  });
+  return true;
 }
 
 export async function deleteServiceDefinition({


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Removed the throttle mechanism in `recordServicePoll` function.

- Simplified the logic for updating service poll timestamps.

- Ensured consistent behavior for database updates without throttling.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>service-definitions.ts</strong><dd><code>Removed throttling logic in `recordServicePoll` function</code>&nbsp; </dd></summary>
<hr>

control-plane/src/modules/service-definitions.ts

<li>Removed the <code>withThrottle</code> wrapper from <code>recordServicePoll</code>.<br> <li> Simplified the function logic for database updates.<br> <li> Ensured the function directly updates the timestamp without <br>throttling.


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/526/files#diff-d551f73785e001b82d9f9f0dd0105e13902295474f00b07f47e1d2770efc91c0">+16/-19</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information