### PR TITLE
fix: Hide buttons in chat and workflow components

### DIFF
--- a/app/components/chat/human-message.tsx
+++ b/app/components/chat/human-message.tsx
@@ -177,7 +177,7 @@ export function HumanMessage({
               <Button
                 size="sm"
                 variant="secondary"
-                className="h-7 bg-primary-foreground/10 hover:bg-primary-foreground/20 text-primary-foreground transition-colors duration-200"
+                className="h-7 bg-primary-foreground/10 hover:bg-primary-foreground/20 text-primary-foreground transition-colors duration-200 hidden"
                 onClick={() => setEditing(true)}
               >
                 <PencilLineIcon className="h-3.5 w-3.5 mr-1" />
@@ -186,7 +186,7 @@ export function HumanMessage({
               <Button
                 size="sm"
                 variant="secondary"
-                className="h-7 bg-primary-foreground/10 hover:bg-primary-foreground/20 text-primary-foreground"
+                className="h-7 bg-primary-foreground/10 hover:bg-primary-foreground/20 text-primary-foreground hidden"
                 onClick={retryMessage}
               >
                 <RefreshCcw className="h-3.5 w-3.5 mr-1" />

--- a/app/components/workflow.tsx
+++ b/app/components/workflow.tsx
@@ -489,7 +489,7 @@ export function Run({ clusterId, runId }: { clusterId: string; runId: string }) 
                   <Button
                     size="sm"
                     variant="outline"
-                    className="h-7 align-end ml-auto"
+                    className="h-7 align-end ml-auto hidden"
                     onClick={async () => {
                       const loading = toast.loading("Retrying run...");
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Hide 'Edit' and 'Retry' buttons in chat component.

- Hide 'Retry' button in workflow component.

- Ensure buttons are conditionally hidden using CSS class.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>human-message.tsx</strong><dd><code>Hide 'Edit' and 'Retry' buttons in chat</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/components/chat/human-message.tsx

<li>Added <code>hidden</code> class to 'Edit' button.<br> <li> Added <code>hidden</code> class to 'Retry' button.<br> <li> Ensured buttons are conditionally hidden in the chat component.


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/541/files#diff-c320f1344923bb27e3fb31c6317675f8f8672cbc62f5cfe3bb4acc12d3271cee">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>workflow.tsx</strong><dd><code>Hide 'Retry' button in workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/components/workflow.tsx

<li>Added <code>hidden</code> class to 'Retry' button.<br> <li> Ensured button is conditionally hidden in the workflow component.


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/541/files#diff-3869bd7c46b85e34e1b64ec4f754b5872b864e1fa5b62051fb65f2af161b9530">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information