### PR TITLE
fix: Remove unused getServerStats endpoint and method

### DIFF
--- a/control-plane/src/modules/contract.ts
+++ b/control-plane/src/modules/contract.ts
@@ -242,23 +242,6 @@ export const definition = {
     },
   },
 
-  getServerStats: {
-    method: "GET",
-    path: "/stats",
-    responses: {
-      200: z.object({
-        functionCalls: z.object({
-          count: z.number(),
-        }),
-        tokenUsage: z.object({
-          input: z.number(),
-          output: z.number(),
-        }),
-        refreshedAt: z.number(),
-      }),
-    },
-  },
-
   createStructuredOutput: {
     method: "POST",
     path: "/clusters/:clusterId/structured-output",

--- a/control-plane/src/modules/router.ts
+++ b/control-plane/src/modules/router.ts
@@ -633,14 +633,6 @@ export const router = initServer().router(contract, {
       body: result.structured,
     };
   },
-  getServerStats: async () => {
-    const stats = await getServerStats();
-
-    return {
-      status: 200,
-      body: stats,
-    };
-  },
   getStandardLibraryMeta: async request => {
     const { clusterId } = request.params;
 

--- a/control-plane/src/modules/router.ts
+++ b/control-plane/src/modules/router.ts
@@ -20,7 +20,6 @@ import { posthog } from "./posthog";
 import { addMessageAndResume, assertRunReady, getRun } from "./runs";
 import { editHumanMessage, getRunMessagesForDisplayWithPolling } from "./runs/messages";
 import { runsRouter } from "./runs/router";
-import { getServerStats } from "./server-stats";
 import { getServiceDefinitions, getStandardLibraryToolsMeta } from "./service-definitions";
 
 const readFile = util.promisify(fs.readFile);


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Removed the unused `getServerStats` endpoint and method.

- Cleaned up related code in `contract.ts` and `router.ts`.

- Improved code maintainability by eliminating dead code.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>contract.ts</strong><dd><code>Remove `getServerStats` endpoint definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

control-plane/src/modules/contract.ts

<li>Removed the <code>getServerStats</code> endpoint definition.<br> <li> Deleted associated response schema for server stats.


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/542/files#diff-b5950839f91929a72fdc1a19dbd99f3c7db3032893deb18743fc93deff2e34bc">+0/-17</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>router.ts</strong><dd><code>Remove `getServerStats` method implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

control-plane/src/modules/router.ts

<li>Removed the <code>getServerStats</code> method implementation.<br> <li> Cleaned up unused server stats retrieval logic.


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/542/files#diff-8ae44be4c7b96ed5ba871dae265ba5e854ab9c80720d80f8f6412ea560fe200a">+0/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information