### PR TITLE
fix: Return e2b logs in result

### DIFF
--- a/control-plane/src/modules/runs/agent/tools/calculator.ts
+++ b/control-plane/src/modules/runs/agent/tools/calculator.ts
@@ -34,6 +34,7 @@ export const calculatorTool = new AgentTool({
         error: result.error,
         results: result.results,
         text: result.text,
+        logs: result.logs,
       },
       resultType: "resolution",
       status: "success",


### PR DESCRIPTION
The logs don't seem to be being returned to the agent

<img width="882" alt="image" src="https://github.com/user-attachments/assets/8f9a85e4-cc1b-4a90-8f0b-3ec0ddceeb18" />
