### PR TITLE
chore: Posthog improvements

### DIFF
--- a/control-plane/src/modules/auth/auth.ts
+++ b/control-plane/src/modules/auth/auth.ts
@@ -471,3 +471,12 @@ export const extractCustomAuthState = async (
     },
   } as CustomAuth;
 };
+
+export const unqualifiedEntityId = (id: string) => {
+  const parts = id.split(":")
+  if (parts.length > 1) {
+    return parts[1];
+  }
+  return id;
+}
+

--- a/control-plane/src/modules/auth/router.ts
+++ b/control-plane/src/modules/auth/router.ts
@@ -2,6 +2,7 @@ import { initServer } from "@ts-rest/fastify";
 import { contract } from "../contract";
 import { createApiKey, listApiKeys, revokeApiKey } from "./cluster";
 import { posthog } from "../posthog";
+import { unqualifiedEntityId } from "./auth";
 
 export const authRouter = initServer().router(
   {
@@ -45,7 +46,7 @@ export const authRouter = initServer().router(
       });
 
       posthog?.capture({
-        distinctId: auth.entityId,
+        distinctId: unqualifiedEntityId(auth.entityId),
         event: "api:api_key_create",
         groups: {
           organization: auth.organizationId,
@@ -87,7 +88,7 @@ export const authRouter = initServer().router(
       await revokeApiKey({ clusterId, keyId });
 
       posthog?.capture({
-        distinctId: auth.entityId,
+        distinctId: unqualifiedEntityId(auth.entityId),
         event: "api:api_key_revoke",
         groups: {
           organization: auth.organizationId,

--- a/control-plane/src/modules/cluster.ts
+++ b/control-plane/src/modules/cluster.ts
@@ -16,6 +16,7 @@ export const getClusterDetails = async (clusterId: string) => {
       additional_context: data.clusters.additional_context,
       organization_id: data.clusters.organization_id,
       deleted_at: data.clusters.deleted_at,
+      is_demo: data.clusters.is_demo,
     })
     .from(data.clusters)
     .where(eq(data.clusters.id, clusterId));

--- a/control-plane/src/modules/runs/router.ts
+++ b/control-plane/src/modules/runs/router.ts
@@ -22,6 +22,8 @@ import {
   addMessageAndResumeWithRun,
   updateRunFeedback,
 } from "./";
+import { unqualifiedEntityId } from "../auth/auth";
+import { getClusterDetails } from "../cluster";
 
 export const runsRouter = initServer().router(
   {
@@ -187,8 +189,10 @@ export const runsRouter = initServer().router(
         });
       }
 
+      const cluster = await getClusterDetails(clusterId);
+
       posthog?.capture({
-        distinctId: auth.entityId,
+        distinctId: unqualifiedEntityId(auth.entityId),
         event: "api:run_create",
         groups: {
           organization: auth.organizationId,
@@ -196,6 +200,7 @@ export const runsRouter = initServer().router(
         },
         properties: {
           cluster_id: clusterId,
+          is_demo: cluster.is_demo,
           run_id: run.id,
           agent_id: run.agentId,
           cli_version: request.headers["x-cli-version"],
@@ -220,7 +225,7 @@ export const runsRouter = initServer().router(
       });
 
       posthog?.capture({
-        distinctId: auth.entityId,
+        distinctId: unqualifiedEntityId(auth.entityId),
         event: "api:run_delete",
         groups: {
           organization: auth.organizationId,
@@ -265,7 +270,7 @@ export const runsRouter = initServer().router(
       });
 
       posthog?.capture({
-        distinctId: auth.entityId,
+        distinctId: unqualifiedEntityId(auth.entityId),
         event: "api:feedback_create",
         groups: {
           organization: auth.organizationId,


### PR DESCRIPTION
- Submit "unqualified" (strip `clerk:`, etc) entity Ids to post hog so clerk sessions can be associated with FE user
- Add `is_demo` property to `api:run_create` event
- Add `api:integration_delete` / `api:integration_update` events