### PR TITLE
feat: Add Slack agentId selector

### DIFF
--- a/app/client/contract.ts
+++ b/app/client/contract.ts
@@ -86,6 +86,7 @@ export const integrationSchema = z.object({
       nangoConnectionId: z.string(),
       botUserId: z.string(),
       teamId: z.string(),
+      agentId: z.string().optional(),
     })
     .optional()
     .nullable(),
@@ -239,23 +240,6 @@ export const definition = {
     responses: {
       200: z.object({
         contract: z.string(),
-      }),
-    },
-  },
-
-  getServerStats: {
-    method: "GET",
-    path: "/stats",
-    responses: {
-      200: z.object({
-        functionCalls: z.object({
-          count: z.number(),
-        }),
-        tokenUsage: z.object({
-          input: z.number(),
-          output: z.number(),
-        }),
-        refreshedAt: z.number(),
       }),
     },
   },

--- a/control-plane/src/modules/contract.ts
+++ b/control-plane/src/modules/contract.ts
@@ -86,6 +86,7 @@ export const integrationSchema = z.object({
       nangoConnectionId: z.string(),
       botUserId: z.string(),
       teamId: z.string(),
+      agentId: z.string().optional(),
     })
     .optional()
     .nullable(),

--- a/control-plane/src/modules/data.ts
+++ b/control-plane/src/modules/data.ts
@@ -215,6 +215,7 @@ export const integrations = pgTable(
       nangoConnectionId: string;
       botUserId: string;
       teamId: string;
+      agentId?: string;
     }>(),
     email: json("email").$type<{
       connectionId: string;

--- a/control-plane/src/modules/integrations/router.ts
+++ b/control-plane/src/modules/integrations/router.ts
@@ -29,7 +29,16 @@ export const integrationsRouter = initServer().router(
       await auth.canManage({ cluster: { clusterId } });
 
       if (request.body.slack) {
-        throw new BadRequestError("Slack integration details are not editable");
+        const integrations = await getIntegrations({ clusterId });
+        if (!integrations.slack) {
+          throw new BadRequestError("Slack integration does not exist");
+        }
+
+        // Only the agentId is editable via the API
+        request.body.slack = {
+          agentId: request.body.slack.agentId,
+          ...integrations.slack
+        }
       }
 
       if (request.body.email) {


### PR DESCRIPTION
Allow Slack messages to be routed via an Agent (consistent with the email integration)

<img width="590" alt="image" src="https://github.com/user-attachments/assets/781f9a80-3432-473c-9cd7-140a37c98e6b" />
