### PR TITLE
fix: Validate valtown response is json

### DIFF
--- a/control-plane/src/modules/integrations/valtown.ts
+++ b/control-plane/src/modules/integrations/valtown.ts
@@ -45,7 +45,7 @@ export async function fetchValTownMeta({
     },
   });
 
-  if (!response.ok) {
+  if (!response.ok || !response.headers.get("content-type")?.includes("application/json")) {
     logger.error("Failed to fetch Val.town metadata", {
       endpoint,
       status: response.status,


### PR DESCRIPTION
Currently the `response.json` throws with:
 ```
 Unexpected token '<', "<html><lin"... is not valid JSON
 ```