### PR TITLE
fix: Use ci --legacy-peer-deps for react publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -151,7 +151,7 @@ jobs:
           cache: "npm"
           cache-dependency-path: sdk-react/package-lock.json
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --legacy-peer-deps # @testing-library/react-hooks@8.0.1 requires @types/react@^16.9.0 || ^17.0.0
       - name: Build package
         run: npm run build
       - name: Configure Git User


### PR DESCRIPTION
`sdk-react` publishing [is failing](https://github.com/inferablehq/inferable/actions/runs/12759612904).

NPM CI is failing because of `@testing-library/react-hooks@8.0.1` requires `@types/react@^16.9.0 || ^17.0.0`.