### PR TITLE
feat: Include user details in authContext

### DIFF
--- a/control-plane/src/modules/email/index.ts
+++ b/control-plane/src/modules/email/index.ts
@@ -425,6 +425,10 @@ const handleNewChain = async ({
     userId,
     clusterId,
     agentId,
+    authContext: {
+      userId,
+      emailAddress: source,
+    },
     tags: {
       [EMAIL_INIT_MESSAGE_ID_META_KEY]: messageId,
       [EMAIL_SUBJECT_META_KEY]: subject,


### PR DESCRIPTION
Include `userId` and `emailAddress` in `authContext` for runs originating from Slack / Email integrations