### PR TITLE
fix: relocate demo video link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Inferable is the easiest way to convert your existing internal APIs, functions, 
 ![NPM Version](https://img.shields.io/npm/v/inferable?color=32CD32&style=for-the-badge) ![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/inferablehq/inferable?filename=sdk-go%2Fgo.mod&color=32CD32&style=for-the-badge) ![NuGet Version](https://img.shields.io/nuget/v/inferable?color=32CD32&style=for-the-badge)
 ![License](https://img.shields.io/github/license/inferablehq/inferable?color=32CD32&style=for-the-badge)
 
-[![Demo Video](https://image.mux.com/uzM4gDXiba4RLkvub01mnUey02p8huyEc02PsA6aTLpLqo/animated.gif?width=640&start=115&fps=30)](https://youtu.be/B8Rl8FT8DpM)
-
 </div>
+
+[![Demo Video](https://image.mux.com/uzM4gDXiba4RLkvub01mnUey02p8huyEc02PsA6aTLpLqo/animated.gif?width=640&start=115&fps=30)](https://youtu.be/B8Rl8FT8DpM)
 
 ## ✨ Features
 


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Relocated the demo video link in `README.md`.

- Adjusted formatting for the demo video section.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Relocate and format demo video link</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Relocated the demo video link.<br> <li> Adjusted formatting by moving the link to a new position.


</details>


  </td>
  <td><a href="https://github.com/inferablehq/inferable/pull/592/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any question about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>