### PR TITLE
chore: Include custom auth route error

### DIFF
--- a/control-plane/src/modules/auth/auth.ts
+++ b/control-plane/src/modules/auth/auth.ts
@@ -98,7 +98,7 @@ export const plugin = fastifyPlugin(async (fastify: FastifyInstance) => {
 
       if (!clusterId) {
         throw new AuthenticationError(
-          "Custom auth can only be used with /clusters/:clusterId paths"
+          `Custom auth can only be used with /clusters/:clusterId paths. Request URL: ${request.url}.`
         );
       }
 


### PR DESCRIPTION
Include request URL in custom auth error to surface problems with the URL which are currently obfuscated by this error message.