### PR TITLE
fix: Sort runs by created at

### DIFF
--- a/app/components/workflow-tab.tsx
+++ b/app/components/workflow-tab.tsx
@@ -108,7 +108,7 @@ export function RunTab({
   return (
     <div className="flex flex-col space-y-2">
       {workflows
-        .sort((a, b) => (a.id > b.id ? -1 : 1))
+        .sort((a, b) => (a.createdAt > b.createdAt ? -1 : 1))
         .map((workflow) => (
           <RunPill
             key={workflow.id}


### PR DESCRIPTION
Now that Run IDs are no longer ULID, sort based on `craetedAt` instead