### PR TITLE
fix: Remove redundant run queue resume

### DIFF
--- a/control-plane/src/modules/runs/agent/nodes/edges.ts
+++ b/control-plane/src/modules/runs/agent/nodes/edges.ts
@@ -16,6 +16,11 @@ export const postStartEdge = async (state: RunGraphState) => {
     return END;
   }
 
+  if (state.messages.length == 0) {
+    logger.error("Attempted to resume run with no messages");
+    return END;
+  }
+
   const lastMessage = state.messages[state.messages.length - 1];
 
   if (lastMessage.type == "agent") {

--- a/control-plane/src/modules/runs/index.ts
+++ b/control-plane/src/modules/runs/index.ts
@@ -142,17 +142,6 @@ export const createRun = async ({
     throw new Error("Failed to create run");
   }
 
-  // Send the run to be processed
-  await runProcessQueue
-    .send({
-      runId: run.id,
-      clusterId,
-      ...injectTraceContext(),
-    })
-    .catch(e => {
-      logger.error("Failed to send run to process queue", { error: e });
-    });
-
   // Insert tags if provided
   if (tags) {
     await db.insert(runTags).values(


### PR DESCRIPTION
`createRun` was attempting to resume the Run _before_ the initial message had been added.

Remove the `runProcessQueue` message from `createRun` and allow this to happen when the first message is added.

Also adds more descriptive error handling.