### PR TITLE
chore: Add toolName to invocation-result message

### DIFF
--- a/app/client/contract.ts
+++ b/app/client/contract.ts
@@ -110,6 +110,7 @@ const genericMessageDataSchema = z
 const resultDataSchema = z
   .object({
     id: z.string(),
+    toolName: z.string().optional(),
     result: z.object({}).passthrough(),
   })
   .strict();

--- a/control-plane/src/modules/contract.ts
+++ b/control-plane/src/modules/contract.ts
@@ -110,6 +110,7 @@ const genericMessageDataSchema = z
 const resultDataSchema = z
   .object({
     id: z.string(),
+    toolName: z.string().optional(),
     result: z.object({}).passthrough(),
   })
   .strict();

--- a/control-plane/src/modules/runs/agent/nodes/tool-call.ts
+++ b/control-plane/src/modules/runs/agent/nodes/tool-call.ts
@@ -364,6 +364,7 @@ const _handleToolCall = async (
               message: `Failed to invoke ${toolName}`,
               error,
             },
+            toolName,
             id: toolCallId,
           },
           runId: run.id,

--- a/sdk-react/src/contract.ts
+++ b/sdk-react/src/contract.ts
@@ -110,6 +110,7 @@ const genericMessageDataSchema = z
 const resultDataSchema = z
   .object({
     id: z.string(),
+    toolName: z.string().optional(),
     result: z.object({}).passthrough(),
   })
   .strict();


### PR DESCRIPTION
- Add `toolName` to invocation result for easier parsing on frontend
- Add polyfill to `getRunMessagesForDisplay` to ensure that older messages have `toolName` populated
