### PR TITLE
fix: Add tool name to invocation messages

### DIFF
--- a/control-plane/src/modules/runs/agent/nodes/tool-call.ts
+++ b/control-plane/src/modules/runs/agent/nodes/tool-call.ts
@@ -161,6 +161,7 @@ const _handleToolCall = async (
               error,
             },
             id: toolCallId,
+            toolName,
           },
           runId: run.id,
           clusterId: run.clusterId,
@@ -232,6 +233,7 @@ const _handleToolCall = async (
               result: {
                 [toolCallId]: response,
               },
+              toolName,
               id: toolCallId,
             },
             runId: run.id,
@@ -316,6 +318,7 @@ const _handleToolCall = async (
                 message: `Provided input did not match schema for ${toolName}, check your input`,
                 parseResult: error.validatorResult.errors,
               },
+              toolName,
               id: toolCallId,
             },
             runId: run.id,

--- a/control-plane/src/modules/runs/messages.ts
+++ b/control-plane/src/modules/runs/messages.ts
@@ -168,7 +168,7 @@ export const getRunMessagesForDisplay = async ({
 
       if (!message.data.toolName) {
         logger.error("Could not find invocation for invocation-result message", {
-          message,
+          msg: message,
         });
       }
     }


### PR DESCRIPTION
Some cases of `invocation-result` messages do not have `toolName` set.