### PR TITLE
feat: Introduce tools table

### DIFF
--- a/control-plane/drizzle/0226_past_captain_marvel.sql
+++ b/control-plane/drizzle/0226_past_captain_marvel.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS "tools" (
+	"cluster_id" varchar NOT NULL,
+	"name" varchar(1024) NOT NULL,
+	"group" varchar(1024) NOT NULL,
+	"description" text,
+	"schema" text,
+	"config" json,
+	"hash" text NOT NULL,
+	"should_expire" boolean NOT NULL,
+	"last_ping_at" timestamp with time zone NOT NULL,
+	"embedding_1024" vector(1024) NOT NULL,
+	"embedding_model" text NOT NULL,
+	"created_at" timestamp (6) with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "tools_cluster_id_tools" PRIMARY KEY("cluster_id","name")
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "tools" ADD CONSTRAINT "tools_cluster_id_clusters_id_fk" FOREIGN KEY ("cluster_id") REFERENCES "public"."clusters"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "toolEmbedding1024Index" ON "tools" USING hnsw ("embedding_1024" vector_cosine_ops);

--- a/control-plane/drizzle/meta/0226_snapshot.json
+++ b/control-plane/drizzle/meta/0226_snapshot.json
@@ -1,0 +1,1885 @@
+{
+  "id": "c972e9d7-e0c2-48f3-828c-ea3120d4ee0e",
+  "prevId": "039b862d-0f0a-4e7c-9a06-a0cc84c05f60",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initial_prompt": {
+          "name": "initial_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attached_functions": {
+          "name": "attached_functions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "structured_output": {
+          "name": "structured_output",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_schema": {
+          "name": "input_schema",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agents_cluster_id_clusters_id_fk": {
+          "name": "agents_cluster_id_clusters_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "prompt_templates_pkey": {
+          "name": "prompt_templates_pkey",
+          "columns": [
+            "cluster_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.analytics_snapshots": {
+      "name": "analytics_snapshots",
+      "schema": "",
+      "columns": {
+        "data": {
+          "name": "data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "analytics_snapshots_pkey": {
+          "name": "analytics_snapshots_pkey",
+          "columns": [
+            "timestamp"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_secret_hash_index": {
+          "name": "api_keys_secret_hash_index",
+          "columns": [
+            {
+              "expression": "secret_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_cluster_id_clusters_id_fk": {
+          "name": "api_keys_cluster_id_clusters_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "api_keys_cluster_id_id_pk": {
+          "name": "api_keys_cluster_id_id_pk",
+          "columns": [
+            "cluster_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.blobs": {
+      "name": "blobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "encoding": {
+          "name": "encoding",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blobs_cluster_id_job_id_jobs_cluster_id_id_fk": {
+          "name": "blobs_cluster_id_job_id_jobs_cluster_id_id_fk",
+          "tableFrom": "blobs",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "cluster_id",
+            "job_id"
+          ],
+          "columnsTo": [
+            "cluster_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "blobs_cluster_id_run_id_runs_cluster_id_id_fk": {
+          "name": "blobs_cluster_id_run_id_runs_cluster_id_id_fk",
+          "tableFrom": "blobs",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "cluster_id",
+            "run_id"
+          ],
+          "columnsTo": [
+            "cluster_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "blobs_cluster_id_id_pk": {
+          "name": "blobs_cluster_id_id_pk",
+          "columns": [
+            "cluster_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.clusters": {
+      "name": "clusters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "debug": {
+          "name": "debug",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enable_custom_auth": {
+          "name": "enable_custom_auth",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "handle_custom_auth_function": {
+          "name": "handle_custom_auth_function",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default_handleCustomAuth'"
+        },
+        "enable_knowledgebase": {
+          "name": "enable_knowledgebase",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_context": {
+          "name": "additional_context",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_demo": {
+          "name": "is_demo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_ephemeral": {
+          "name": "is_ephemeral",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "clusters_id_org_index": {
+          "name": "clusters_id_org_index",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.embeddings": {
+      "name": "embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_1024": {
+          "name": "embedding_1024",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_data_hash": {
+          "name": "raw_data_hash",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "embedding1024Index": {
+          "name": "embedding1024Index",
+          "columns": [
+            {
+              "expression": "embedding_1024",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "embeddingsLookupIndex": {
+          "name": "embeddingsLookupIndex",
+          "columns": [
+            {
+              "expression": "cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "raw_data_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "embeddings_cluster_id_id_type_pk": {
+          "name": "embeddings_cluster_id_id_type_pk",
+          "columns": [
+            "cluster_id",
+            "id",
+            "type"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "machine_id": {
+          "name": "machine_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_fn": {
+          "name": "target_fn",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_type": {
+          "name": "result_type",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_usage_input": {
+          "name": "token_usage_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_usage_output": {
+          "name": "token_usage_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attention_level": {
+          "name": "attention_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        }
+      },
+      "indexes": {
+        "timeline_index": {
+          "name": "timeline_index",
+          "columns": [
+            {
+              "expression": "cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attention_level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.external_messages": {
+      "name": "external_messages",
+      "schema": "",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "externalMessagesIndex": {
+          "name": "externalMessagesIndex",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "external_messages_message_id_run_id_cluster_id_run_messages_id_run_id_cluster_id_fk": {
+          "name": "external_messages_message_id_run_id_cluster_id_run_messages_id_run_id_cluster_id_fk",
+          "tableFrom": "external_messages",
+          "tableTo": "run_messages",
+          "columnsFrom": [
+            "message_id",
+            "run_id",
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id",
+            "run_id",
+            "cluster_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "external_messages_pkey": {
+          "name": "external_messages_pkey",
+          "columns": [
+            "cluster_id",
+            "external_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.integrations": {
+      "name": "integrations",
+      "schema": "",
+      "columns": {
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "toolhouse": {
+          "name": "toolhouse",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "langfuse": {
+          "name": "langfuse",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tavily": {
+          "name": "tavily",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valtown": {
+          "name": "valtown",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack": {
+          "name": "slack",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "integrations_cluster_id_clusters_id_fk": {
+          "name": "integrations_cluster_id_clusters_id_fk",
+          "tableFrom": "integrations",
+          "tableTo": "clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "integrations_pkey": {
+          "name": "integrations_pkey",
+          "columns": [
+            "cluster_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_fn": {
+          "name": "target_fn",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_args": {
+          "name": "target_args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_key": {
+          "name": "cache_key",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_type": {
+          "name": "result_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executing_machine_id": {
+          "name": "executing_machine_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remaining_attempts": {
+          "name": "remaining_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resulted_at": {
+          "name": "resulted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_retrieved_at": {
+          "name": "last_retrieved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "function_execution_time_ms": {
+          "name": "function_execution_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeout_interval_seconds": {
+          "name": "timeout_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_context": {
+          "name": "auth_context",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_context": {
+          "name": "run_context",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_requested": {
+          "name": "approval_requested",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approved": {
+          "name": "approved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clusterServiceStatusIndex": {
+          "name": "clusterServiceStatusIndex",
+          "columns": [
+            {
+              "expression": "cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "service",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clusterServiceStatusFnIndex": {
+          "name": "clusterServiceStatusFnIndex",
+          "columns": [
+            {
+              "expression": "cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "service",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_fn",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "jobs_cluster_id_id": {
+          "name": "jobs_cluster_id_id",
+          "columns": [
+            "cluster_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "jobs_id_unique": {
+          "name": "jobs_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "public.machines": {
+      "name": "machines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_ping_at": {
+          "name": "last_ping_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sdk_version": {
+          "name": "sdk_version",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sdk_language": {
+          "name": "sdk_language",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "machines_id_cluster_id": {
+          "name": "machines_id_cluster_id",
+          "columns": [
+            "id",
+            "cluster_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.run_messages": {
+      "name": "run_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "run_messages_run_id_cluster_id_runs_id_cluster_id_fk": {
+          "name": "run_messages_run_id_cluster_id_runs_id_cluster_id_fk",
+          "tableFrom": "run_messages",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id",
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id",
+            "cluster_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_messages_cluster_id_run_id_id": {
+          "name": "run_messages_cluster_id_run_id_id",
+          "columns": [
+            "cluster_id",
+            "run_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.run_tags": {
+      "name": "run_tags",
+      "schema": "",
+      "columns": {
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "runTagsIndex": {
+          "name": "runTagsIndex",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_tags_run_id_cluster_id_runs_id_cluster_id_fk": {
+          "name": "run_tags_run_id_cluster_id_runs_id_cluster_id_fk",
+          "tableFrom": "run_tags",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id",
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id",
+            "cluster_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_tags_cluster_id_run_id_key": {
+          "name": "run_tags_cluster_id_run_id_key",
+          "columns": [
+            "cluster_id",
+            "run_id",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.runs": {
+      "name": "runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "on_status_change": {
+          "name": "on_status_change",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_schema": {
+          "name": "result_schema",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_identifier": {
+          "name": "model_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debug": {
+          "name": "debug",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "attached_functions": {
+          "name": "attached_functions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "test": {
+          "name": "test",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "test_mocks": {
+          "name": "test_mocks",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::json"
+        },
+        "feedback_comment": {
+          "name": "feedback_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_score": {
+          "name": "feedback_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_version": {
+          "name": "agent_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_traces": {
+          "name": "reasoning_traces",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "interactive": {
+          "name": "interactive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_summarization": {
+          "name": "enable_summarization",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enable_result_grounding": {
+          "name": "enable_result_grounding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auth_context": {
+          "name": "auth_context",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "runs_cluster_id_clusters_id_fk": {
+          "name": "runs_cluster_id_clusters_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workflows_cluster_id_id": {
+          "name": "workflows_cluster_id_id",
+          "columns": [
+            "cluster_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.services": {
+      "name": "services",
+      "schema": "",
+      "columns": {
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_trigger_endpoint": {
+          "name": "http_trigger_endpoint",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "services_cluster_id_clusters_id_fk": {
+          "name": "services_cluster_id_clusters_id_fk",
+          "tableFrom": "services",
+          "tableTo": "clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "services_cluster_id_service": {
+          "name": "services_cluster_id_service",
+          "columns": [
+            "cluster_id",
+            "service"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.tools": {
+      "name": "tools",
+      "schema": "",
+      "columns": {
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group": {
+          "name": "group",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema": {
+          "name": "schema",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "should_expire": {
+          "name": "should_expire",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_ping_at": {
+          "name": "last_ping_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_1024": {
+          "name": "embedding_1024",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "toolEmbedding1024Index": {
+          "name": "toolEmbedding1024Index",
+          "columns": [
+            {
+              "expression": "embedding_1024",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tools_cluster_id_clusters_id_fk": {
+          "name": "tools_cluster_id_clusters_id_fk",
+          "tableFrom": "tools",
+          "tableTo": "clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tools_cluster_id_tools": {
+          "name": "tools_cluster_id_tools",
+          "columns": [
+            "cluster_id",
+            "name"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.versioned_entities": {
+      "name": "versioned_entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "versioned_entities_pkey": {
+          "name": "versioned_entities_pkey",
+          "columns": [
+            "cluster_id",
+            "id",
+            "type",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.workflow_executions": {
+      "name": "workflow_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_execution_id": {
+          "name": "workflow_execution_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "workflow_executions_pkey": {
+          "name": "workflow_executions_pkey",
+          "columns": [
+            "cluster_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/control-plane/drizzle/meta/_journal.json
+++ b/control-plane/drizzle/meta/_journal.json
@@ -1576,6 +1576,13 @@
       "when": 1738619376564,
       "tag": "0225_absurd_ben_urich",
       "breakpoints": true
+    },
+    {
+      "idx": 226,
+      "version": "7",
+      "when": 1738635030958,
+      "tag": "0226_past_captain_marvel",
+      "breakpoints": true
     }
   ]
 }

--- a/control-plane/src/bootstrap.ts
+++ b/control-plane/src/bootstrap.ts
@@ -19,6 +19,7 @@ import * as clusters from "./modules/cluster";
 import * as redis from "./modules/redis";
 import * as router from "./modules/router";
 import * as serviceDefinitions from "./modules/service-definitions";
+import * as tools from "./modules/tools";
 import * as cron from "./modules/cron";
 import { env } from "./utilities/env";
 import { runMigrations } from "./utilities/migrate";
@@ -169,6 +170,7 @@ const startTime = Date.now();
     events.initialize(),
     jobs.start(),
     serviceDefinitions.start(),
+    tools.start(),
     models.start(),
     redis.start(),
     slack.start(app),

--- a/control-plane/src/modules/contract.ts
+++ b/control-plane/src/modules/contract.ts
@@ -260,7 +260,7 @@ export type MessageTypes =
 
 export type UnifiedMessageOfType<T extends MessageTypes> = Extract<UnifiedMessage, { type: T }>;
 
-export const FunctionConfigSchema = z.object({
+export const ToolConfigSchema = z.object({
   cache: z
     .object({
       keyPath: z.string(),
@@ -578,7 +578,7 @@ export const definition = {
             name: z.string(),
             description: z.string().optional(),
             schema: z.string().optional(),
-            config: FunctionConfigSchema.optional(),
+            config: ToolConfigSchema.optional(),
           })
         )
         .optional(),
@@ -1108,7 +1108,7 @@ export const definition = {
                 name: z.string(),
                 description: z.string().optional(),
                 schema: z.string().optional(),
-                config: FunctionConfigSchema.optional(),
+                config: ToolConfigSchema.optional(),
               })
             )
             .optional(),

--- a/control-plane/src/modules/router.ts
+++ b/control-plane/src/modules/router.ts
@@ -50,6 +50,7 @@ import { integrationByConnectionId } from "./email";
 import { NEW_CONNECTION_ID } from "./integrations/constants";
 import { createWorkflowExecution } from "./workflows/executions";
 import { RunOptions, validateSchema } from "./runs";
+import { upsertToolDefinition } from "./tools";
 
 const readFile = util.promisify(fs.readFile);
 
@@ -103,6 +104,16 @@ export const router = initServer().router(contract, {
           },
           owner: machine,
         }),
+      derefedFns && derefedFns?.map(fn =>
+        upsertToolDefinition({
+          name: fn.name,
+          clusterId: machine.clusterId,
+          group: service,
+          description: fn.description,
+          schema: fn.schema,
+          config: fn.config,
+        }),
+      ),
     ]);
 
     events.write({

--- a/control-plane/src/modules/service-definitions.ts
+++ b/control-plane/src/modules/service-definitions.ts
@@ -4,7 +4,7 @@ import jsonpath from "jsonpath";
 import { Validator } from "jsonschema";
 import { z } from "zod";
 import { InvalidJobArgumentsError, InvalidServiceRegistrationError } from "../utilities/errors";
-import { FunctionConfigSchema } from "./contract";
+import { ToolConfigSchema } from "./contract";
 import * as cron from "./cron";
 import * as data from "./data";
 import { embeddableEntitiy } from "./embeddings/embeddings";
@@ -14,7 +14,7 @@ import { packer } from "./packer";
 // The time without a ping before a service is considered expired
 const SERVICE_LIVE_THRESHOLD_MS = 60 * 1000; // 1 minute
 
-export type FunctionConfig = z.infer<typeof FunctionConfigSchema>;
+export type FunctionConfig = z.infer<typeof ToolConfigSchema>;
 
 export type ServiceDefinition = {
   name: string;
@@ -39,7 +39,7 @@ export const storedServiceDefinitionSchema = z.array(
           name: z.string(),
           description: z.string().optional(),
           schema: z.string().optional(),
-          config: FunctionConfigSchema.optional(),
+          config: ToolConfigSchema.optional(),
         })
       )
       .optional(),

--- a/control-plane/src/modules/tools/index.ts
+++ b/control-plane/src/modules/tools/index.ts
@@ -1,0 +1,176 @@
+import * as cron from "../cron";
+import * as crypto from "crypto";
+import * as data from "../data";
+import { ToolConfigSchema } from "../contract";
+import { z } from "zod";
+import { and, eq, lte } from "drizzle-orm";
+import { buildModel } from "../models";
+import { validateDescription, validateFunctionName, validateFunctionSchema, validateServiceName } from "inferable";
+import { InvalidServiceRegistrationError } from "../../utilities/errors";
+import jsonpath from "jsonpath";
+import { logger } from "../observability/logger";
+
+// The time without a ping before a tool is considered expired
+const TOOL_LIVE_THRESHOLD_MS = 60 * 1000; // 1 minute
+
+export type ToolConfig = z.infer<typeof ToolConfigSchema>;
+
+export async function recordToolPoll({
+  clusterId,
+  name,
+}: {
+  clusterId: string;
+  name: string;
+}) {
+  const result = await data.db
+    .update(data.tools)
+    .set({
+      last_ping_at: new Date(),
+    })
+    .where(
+      and(
+        eq(data.tools.cluster_id, clusterId),
+        eq(data.tools.name, name)
+      )
+    )
+    .returning({
+      tools: data.tools.name,
+    });
+
+  if (result.length === 0) {
+    return false;
+  }
+
+  return true;
+}
+
+export async function upsertToolDefinition({
+  name,
+  description,
+  schema,
+  config,
+  clusterId,
+  group = "default",
+  shouldExpire = true,
+}: {
+  name: string;
+  description?: string;
+  schema?: string;
+  config?: ToolConfig;
+  clusterId: string;
+  group?: string;
+  shouldExpire?: boolean;
+}) {
+
+  validateFunctionName(name);
+  validateServiceName(group);
+  validateDescription(description);
+
+  if (!schema) {
+    throw new InvalidServiceRegistrationError("Schema is required");
+  }
+
+  const errors = validateFunctionSchema(JSON.parse(schema));
+  if (errors.length > 0) {
+    throw new InvalidServiceRegistrationError(
+      `${name} schema invalid: ${JSON.stringify(errors)}`
+    );
+  }
+
+  if (config?.cache) {
+    try {
+      jsonpath.parse(config.cache.keyPath);
+    } catch {
+      throw new InvalidServiceRegistrationError(
+        `${name} cache.keyPath is invalid`,
+        "https://docs.inferable.ai/pages/functions#config-cache"
+      );
+    }
+  }
+
+  const hash = crypto
+    .createHash("sha256")
+    .update(JSON.stringify({
+      name,
+      description,
+      schema,
+      config
+    }))
+    .digest("hex");
+
+  // Check if definition has changed
+  const [existing] = await data.db
+    .select({ id: data.tools.name })
+    .from(data.tools)
+    .where(
+      and(
+        eq(data.tools.cluster_id, clusterId),
+        eq(data.tools.name, name),
+        eq(data.tools.hash, hash),
+      )
+    );
+
+  if (existing) {
+    return;
+  }
+
+  const embedding = await buildModel({ identifier: "embed-english-v3" }).embedQuery(
+    JSON.stringify({
+      name,
+      description,
+      schema,
+    }),
+  );
+
+  await data.db
+    .insert(data.tools)
+    .values({
+      name,
+      description,
+      schema,
+      config,
+      cluster_id: clusterId,
+      last_ping_at: new Date(),
+      group,
+      should_expire: shouldExpire,
+      embedding_1024: embedding,
+      embedding_model: "embed-english-v3",
+      hash,
+    })
+    .onConflictDoUpdate({
+      target: [data.tools.name, data.tools.cluster_id],
+      set: {
+        config,
+        schema,
+        description,
+        group,
+        last_ping_at: new Date(),
+      },
+    });
+}
+
+export const cleanExpiredToolDefinitions = async (): Promise<void> => {
+  const toolDefinitions = await data.db
+    .delete(data.tools)
+    .where(
+      and(
+        eq(data.tools.should_expire, true),
+        lte(
+          data.tools.last_ping_at, new Date(Date.now() - TOOL_LIVE_THRESHOLD_MS)
+        )
+      )
+    ).returning({
+      clusterId: data.tools.cluster_id,
+      name: data.tools.name,
+    });
+
+  logger.info("Cleaned up expired tool definition", {
+    tools: toolDefinitions,
+  });
+};
+
+
+export const start = () =>
+  cron.registerCron(cleanExpiredToolDefinitions, "clean-tool-definitions", {
+    interval: 1000 * 10,
+  }); // 10 seconds


### PR DESCRIPTION
Introduces a new 'tools' table which is decoupled from services.

The tools table will store a tool's definition *and* embedding information.

This PR adds the new table and updates `createMachine` route to start storing the tools in the new table.

Seperate PRs will be created to:
- Support polling the individual tools from the SDKs
- Update the agent function search to use the new tools table