### PR TITLE
feat: More restrictive tool names

### DIFF
--- a/control-plane/src/modules/tools/index.ts
+++ b/control-plane/src/modules/tools/index.ts
@@ -220,7 +220,7 @@ export async function upsertToolDefinition({
   clusterId: string;
   shouldExpire?: boolean;
 }) {
-  validateToolName(name);
+  validateToolName(name, config?.private ?? false);
   validateToolDescription(description);
 
   if (!schema) {

--- a/control-plane/src/modules/tools/validations.ts
+++ b/control-plane/src/modules/tools/validations.ts
@@ -21,7 +21,7 @@ export type JsonSchemaInput = {
   $schema: string;
 };
 
-export function validateToolName(name: string) {
+export function validateToolName(name: string, isPrivate: boolean) {
   if (!name) {
     throw new InvalidServiceRegistrationError("Tool name is required");
   }
@@ -31,9 +31,24 @@ export function validateToolName(name: string) {
     throw new InvalidServiceRegistrationError("Tool name must be 50 characters or less");
   }
 
-  // allows alphanumeric, and dots
-  if (!/^[a-zA-Z0-9._-]+$/.test(name)) {
-    throw new InvalidServiceRegistrationError(`Tool name must be alphanumeric and can contain hyphen, underscore and priod, got ${name}`);
+  logger.info("Validating tool name", {
+    name,
+    isPrivate,
+  });
+
+  // Private functions are less restrictive as they don't pass through the model
+  if (isPrivate) {
+    // private functions can have alphanumeric, hyphen, underscore and period
+    // The inclusion of period is to support workflow handlers
+    if (!/^[a-zA-Z0-9._-]+$/.test(name)) {
+      throw new InvalidServiceRegistrationError(`Private Tools can have alphanumeric, hyphen, underscore and period, got ${name}`);
+    }
+  } else {
+    // public functions can have alphanumeric, hyphen, underscore
+    // https://docs.anthropic.com/en/docs/build-with-claude/tool-use
+    if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
+      throw new InvalidServiceRegistrationError(`Tools can have alphanumeric, hyphen and underscore got ${name}`);
+    }
   }
 }
 

--- a/sdk-node/src/Inferable.test.ts
+++ b/sdk-node/src/Inferable.test.ts
@@ -15,7 +15,7 @@ const testService = () => {
   const prefix = `test${Math.random().toString(36).substring(2, 15)}`;
 
   client.tools.register({
-    name: `${prefix}.echo`,
+    name: `${prefix}_echo`,
     func: async (input: { text: string }) => {
       return { echo: input.text };
     },
@@ -27,7 +27,7 @@ const testService = () => {
   });
 
   client.tools.register({
-    name: `${prefix}.error`,
+    name: `${prefix}_error`,
     func: async (_input) => {
       throw new Error("This is an error");
     },
@@ -89,7 +89,7 @@ describe("Functions", () => {
           },
           body: {
             service: "v2",
-            function: `${service.prefix}.echo`,
+            function: `${service.prefix}_echo`,
             input: { text: i.toString() },
           },
         });
@@ -143,7 +143,7 @@ describe("Functions", () => {
       },
       body: {
         service: "v2",
-        function: `${service.prefix}.echo`,
+        function: `${service.prefix}_echo`,
         input: { text: "foo" },
       },
     });

--- a/sdk-node/src/tests/errors/animals.ts
+++ b/sdk-node/src/tests/errors/animals.ts
@@ -21,7 +21,7 @@ export const animalService = () => {
   const client = inferableInstance()
 
   client.tools.register ({
-    name: `${prefix}.getNormalAnimal`,
+    name: `${prefix}_getNormalAnimal`,
     func: getNormalAnimal,
     schema: {
       input: z.object({}),
@@ -29,7 +29,7 @@ export const animalService = () => {
   });
 
   client.tools.register({
-    name: `${prefix}.getCustomAnimal`,
+    name: `${prefix}_getCustomAnimal`,
     func: getCustomAnimal,
     schema: {
       input: z.object({}),

--- a/sdk-node/src/tests/errors/errors.test.ts
+++ b/sdk-node/src/tests/errors/errors.test.ts
@@ -23,7 +23,7 @@ describe("Errors", () => {
       },
       body: {
         service: "v2",
-        function: `${service.prefix}.getNormalAnimal`,
+        function: `${service.prefix}_getNormalAnimal`,
         input: {},
       },
     });
@@ -53,7 +53,7 @@ describe("Errors", () => {
       },
       body: {
         service: "v2",
-        function: `${service.prefix}.getCustomAnimal`,
+        function: `${service.prefix}_getCustomAnimal`,
         input: {},
       },
     });

--- a/sdk-node/src/tests/utility/caching.test.ts
+++ b/sdk-node/src/tests/utility/caching.test.ts
@@ -25,7 +25,7 @@ describe("Caching", () => {
       },
       body: {
         service: "v2",
-        function: `${service.prefix}.getProduct10sCache`,
+        function: `${service.prefix}_getProduct10sCache`,
         input: { id: productId, random: "foo" },
       },
     });
@@ -39,7 +39,7 @@ describe("Caching", () => {
       },
       body: {
         service: "v2",
-        function: `${service.prefix}.getProduct10sCache`,
+        function: `${service.prefix}_getProduct10sCache`,
         input: { id: productId, random: "foo" },
       },
     });
@@ -71,7 +71,7 @@ describe("Caching", () => {
       },
       body: {
         service: "v2",
-        function: `${service.prefix}.getProduct1sCache`,
+        function: `${service.prefix}_getProduct1sCache`,
         input: { id: productId, random: "foo" },
       },
     });
@@ -87,7 +87,7 @@ describe("Caching", () => {
       },
       body: {
         service: "v2",
-        function: `${service.prefix}.getProduct1sCache`,
+        function: `${service.prefix}_getProduct1sCache`,
         input: { id: productId, random: "bar" },
       },
     });

--- a/sdk-node/src/tests/utility/product.ts
+++ b/sdk-node/src/tests/utility/product.ts
@@ -32,7 +32,7 @@ export const productService = () => {
   const client = inferableInstance();
 
   client.tools.register({
-    name: `${prefix}.getProduct10sCache`,
+    name: `${prefix}_getProduct10sCache`,
     func: getProduct,
     schema: {
       input: z.object({
@@ -51,7 +51,7 @@ export const productService = () => {
   });
 
   client.tools.register({
-    name: `${prefix}.getProduct1sCache`,
+    name: `${prefix}_getProduct1sCache`,
     func: getProduct,
     schema: {
       input: z.object({
@@ -70,7 +70,7 @@ export const productService = () => {
   });
 
   client.tools.register({
-    name: `${prefix}.failingFunction`,
+    name: `${prefix}_failingFunction`,
     func: async () => {
       await new Promise((resolve) => setTimeout(resolve, 5000));
     },
@@ -86,7 +86,7 @@ export const productService = () => {
   });
 
   client.tools.register({
-    name: `${prefix}.succeedsOnSecondAttempt`,
+    name: `${prefix}_succeedsOnSecondAttempt`,
     func: succeedsOnSecondAttempt,
     schema: {
       input: z.object({

--- a/sdk-node/src/tests/utility/retry.test.ts
+++ b/sdk-node/src/tests/utility/retry.test.ts
@@ -25,7 +25,7 @@ describe("retrying", () => {
       },
       body: {
         service: "v2",
-        function: `${service.prefix}.failingFunction`,
+        function: `${service.prefix}_failingFunction`,
         input: { id: productId },
       },
     });
@@ -52,7 +52,7 @@ describe("retrying", () => {
       },
       body: {
         service: "v2",
-        function: `${service.prefix}.succeedsOnSecondAttempt`,
+        function: `${service.prefix}_succeedsOnSecondAttempt`,
         input: { id: productId },
       },
     });


### PR DESCRIPTION
Make tool name Restriction stricter for
[public](https://docs.inferable.ai/pages/functions#config) tools.

This is to avoid running into Claude's
[validations](https://docs.anthropic.com/en/docs/build-with-claude/tool-use#specifying-tools)