### PR TITLE
feat: 'simple' Run support

### DIFF
--- a/control-plane/drizzle/0232_awesome_tusk.sql
+++ b/control-plane/drizzle/0232_awesome_tusk.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "runs" ADD COLUMN "type" text DEFAULT 'react' NOT NULL;

--- a/control-plane/drizzle/0232_awesome_tusk.sql
+++ b/control-plane/drizzle/0232_awesome_tusk.sql
@@ -1,1 +1,0 @@
-ALTER TABLE "runs" ADD COLUMN "type" text DEFAULT 'react' NOT NULL;

--- a/control-plane/drizzle/0232_narrow_paper_doll.sql
+++ b/control-plane/drizzle/0232_narrow_paper_doll.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "runs" ADD COLUMN "type" text DEFAULT 'multi-step' NOT NULL;

--- a/control-plane/drizzle/meta/0232_snapshot.json
+++ b/control-plane/drizzle/meta/0232_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "77724fca-6bf4-46e3-8030-e111062d17e4",
+  "id": "4b4e343b-a77d-4d26-80d7-ab22379ff6db",
   "prevId": "1390efe3-1a1b-44e3-90b9-c4ee8ee529c8",
   "version": "7",
   "dialect": "postgresql",
@@ -1539,7 +1539,7 @@
           "type": "text",
           "primaryKey": false,
           "notNull": true,
-          "default": "'react'"
+          "default": "'multi-step'"
         },
         "interactive": {
           "name": "interactive",

--- a/control-plane/drizzle/meta/0232_snapshot.json
+++ b/control-plane/drizzle/meta/0232_snapshot.json
@@ -1,0 +1,1934 @@
+{
+  "id": "77724fca-6bf4-46e3-8030-e111062d17e4",
+  "prevId": "1390efe3-1a1b-44e3-90b9-c4ee8ee529c8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initial_prompt": {
+          "name": "initial_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attached_functions": {
+          "name": "attached_functions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "structured_output": {
+          "name": "structured_output",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_schema": {
+          "name": "input_schema",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agents_cluster_id_clusters_id_fk": {
+          "name": "agents_cluster_id_clusters_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "prompt_templates_pkey": {
+          "name": "prompt_templates_pkey",
+          "columns": [
+            "cluster_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.analytics_snapshots": {
+      "name": "analytics_snapshots",
+      "schema": "",
+      "columns": {
+        "data": {
+          "name": "data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "analytics_snapshots_pkey": {
+          "name": "analytics_snapshots_pkey",
+          "columns": [
+            "timestamp"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_secret_hash_index": {
+          "name": "api_keys_secret_hash_index",
+          "columns": [
+            {
+              "expression": "secret_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_cluster_id_clusters_id_fk": {
+          "name": "api_keys_cluster_id_clusters_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "api_keys_cluster_id_id_pk": {
+          "name": "api_keys_cluster_id_id_pk",
+          "columns": [
+            "cluster_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.blobs": {
+      "name": "blobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "encoding": {
+          "name": "encoding",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blobs_cluster_id_job_id_jobs_cluster_id_id_fk": {
+          "name": "blobs_cluster_id_job_id_jobs_cluster_id_id_fk",
+          "tableFrom": "blobs",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "cluster_id",
+            "job_id"
+          ],
+          "columnsTo": [
+            "cluster_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "blobs_cluster_id_run_id_runs_cluster_id_id_fk": {
+          "name": "blobs_cluster_id_run_id_runs_cluster_id_id_fk",
+          "tableFrom": "blobs",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "cluster_id",
+            "run_id"
+          ],
+          "columnsTo": [
+            "cluster_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "blobs_cluster_id_id_pk": {
+          "name": "blobs_cluster_id_id_pk",
+          "columns": [
+            "cluster_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.cluster_kv": {
+      "name": "cluster_kv",
+      "schema": "",
+      "columns": {
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "cluster_kv_cluster_id_key_pk": {
+          "name": "cluster_kv_cluster_id_key_pk",
+          "columns": [
+            "cluster_id",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.clusters": {
+      "name": "clusters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "debug": {
+          "name": "debug",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enable_custom_auth": {
+          "name": "enable_custom_auth",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "handle_custom_auth_function": {
+          "name": "handle_custom_auth_function",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default_handleCustomAuth'"
+        },
+        "enable_knowledgebase": {
+          "name": "enable_knowledgebase",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_context": {
+          "name": "additional_context",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_demo": {
+          "name": "is_demo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_ephemeral": {
+          "name": "is_ephemeral",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "clusters_id_org_index": {
+          "name": "clusters_id_org_index",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.embeddings": {
+      "name": "embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_1024": {
+          "name": "embedding_1024",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_data_hash": {
+          "name": "raw_data_hash",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "embedding1024Index": {
+          "name": "embedding1024Index",
+          "columns": [
+            {
+              "expression": "embedding_1024",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "embeddingsLookupIndex": {
+          "name": "embeddingsLookupIndex",
+          "columns": [
+            {
+              "expression": "cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "raw_data_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "embeddings_cluster_id_id_type_pk": {
+          "name": "embeddings_cluster_id_id_type_pk",
+          "columns": [
+            "cluster_id",
+            "id",
+            "type"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "machine_id": {
+          "name": "machine_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_fn": {
+          "name": "target_fn",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_type": {
+          "name": "result_type",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_usage_input": {
+          "name": "token_usage_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_usage_output": {
+          "name": "token_usage_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attention_level": {
+          "name": "attention_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        }
+      },
+      "indexes": {
+        "timeline_index": {
+          "name": "timeline_index",
+          "columns": [
+            {
+              "expression": "cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attention_level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.external_messages": {
+      "name": "external_messages",
+      "schema": "",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "externalMessagesIndex": {
+          "name": "externalMessagesIndex",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "external_messages_message_id_run_id_cluster_id_run_messages_id_run_id_cluster_id_fk": {
+          "name": "external_messages_message_id_run_id_cluster_id_run_messages_id_run_id_cluster_id_fk",
+          "tableFrom": "external_messages",
+          "tableTo": "run_messages",
+          "columnsFrom": [
+            "message_id",
+            "run_id",
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id",
+            "run_id",
+            "cluster_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "external_messages_pkey": {
+          "name": "external_messages_pkey",
+          "columns": [
+            "cluster_id",
+            "external_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.integrations": {
+      "name": "integrations",
+      "schema": "",
+      "columns": {
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "toolhouse": {
+          "name": "toolhouse",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "langfuse": {
+          "name": "langfuse",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tavily": {
+          "name": "tavily",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valtown": {
+          "name": "valtown",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack": {
+          "name": "slack",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "integrations_cluster_id_clusters_id_fk": {
+          "name": "integrations_cluster_id_clusters_id_fk",
+          "tableFrom": "integrations",
+          "tableTo": "clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "integrations_pkey": {
+          "name": "integrations_pkey",
+          "columns": [
+            "cluster_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_fn": {
+          "name": "target_fn",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_args": {
+          "name": "target_args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_key": {
+          "name": "cache_key",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_type": {
+          "name": "result_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executing_machine_id": {
+          "name": "executing_machine_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remaining_attempts": {
+          "name": "remaining_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resulted_at": {
+          "name": "resulted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_retrieved_at": {
+          "name": "last_retrieved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "function_execution_time_ms": {
+          "name": "function_execution_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeout_interval_seconds": {
+          "name": "timeout_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_context": {
+          "name": "auth_context",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_context": {
+          "name": "run_context",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_requested": {
+          "name": "approval_requested",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approved": {
+          "name": "approved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clusterServiceStatusIndex": {
+          "name": "clusterServiceStatusIndex",
+          "columns": [
+            {
+              "expression": "cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "service",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clusterServiceStatusFnIndex": {
+          "name": "clusterServiceStatusFnIndex",
+          "columns": [
+            {
+              "expression": "cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "service",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_fn",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "jobs_cluster_id_id": {
+          "name": "jobs_cluster_id_id",
+          "columns": [
+            "cluster_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "jobs_id_unique": {
+          "name": "jobs_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "public.machines": {
+      "name": "machines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_ping_at": {
+          "name": "last_ping_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sdk_version": {
+          "name": "sdk_version",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sdk_language": {
+          "name": "sdk_language",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "machines_id_cluster_id": {
+          "name": "machines_id_cluster_id",
+          "columns": [
+            "id",
+            "cluster_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.run_messages": {
+      "name": "run_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "run_messages_run_id_cluster_id_runs_id_cluster_id_fk": {
+          "name": "run_messages_run_id_cluster_id_runs_id_cluster_id_fk",
+          "tableFrom": "run_messages",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id",
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id",
+            "cluster_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_messages_cluster_id_run_id_id": {
+          "name": "run_messages_cluster_id_run_id_id",
+          "columns": [
+            "cluster_id",
+            "run_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.run_tags": {
+      "name": "run_tags",
+      "schema": "",
+      "columns": {
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "runTagsIndex": {
+          "name": "runTagsIndex",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_tags_run_id_cluster_id_runs_id_cluster_id_fk": {
+          "name": "run_tags_run_id_cluster_id_runs_id_cluster_id_fk",
+          "tableFrom": "run_tags",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id",
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id",
+            "cluster_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "run_tags_cluster_id_run_id_key": {
+          "name": "run_tags_cluster_id_run_id_key",
+          "columns": [
+            "cluster_id",
+            "run_id",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.runs": {
+      "name": "runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "on_status_change": {
+          "name": "on_status_change",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_schema": {
+          "name": "result_schema",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_identifier": {
+          "name": "model_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debug": {
+          "name": "debug",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "attached_functions": {
+          "name": "attached_functions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "test": {
+          "name": "test",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "test_mocks": {
+          "name": "test_mocks",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::json"
+        },
+        "feedback_comment": {
+          "name": "feedback_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_score": {
+          "name": "feedback_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_version": {
+          "name": "agent_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_traces": {
+          "name": "reasoning_traces",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'react'"
+        },
+        "interactive": {
+          "name": "interactive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_summarization": {
+          "name": "enable_summarization",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enable_result_grounding": {
+          "name": "enable_result_grounding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auth_context": {
+          "name": "auth_context",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_execution_id": {
+          "name": "workflow_execution_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_version": {
+          "name": "workflow_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "runs_cluster_id_clusters_id_fk": {
+          "name": "runs_cluster_id_clusters_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workflows_cluster_id_id": {
+          "name": "workflows_cluster_id_id",
+          "columns": [
+            "cluster_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.services": {
+      "name": "services",
+      "schema": "",
+      "columns": {
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_trigger_endpoint": {
+          "name": "http_trigger_endpoint",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "services_cluster_id_clusters_id_fk": {
+          "name": "services_cluster_id_clusters_id_fk",
+          "tableFrom": "services",
+          "tableTo": "clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "services_cluster_id_service": {
+          "name": "services_cluster_id_service",
+          "columns": [
+            "cluster_id",
+            "service"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.tools": {
+      "name": "tools",
+      "schema": "",
+      "columns": {
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema": {
+          "name": "schema",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "should_expire": {
+          "name": "should_expire",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_ping_at": {
+          "name": "last_ping_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_1024": {
+          "name": "embedding_1024",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "toolEmbedding1024Index": {
+          "name": "toolEmbedding1024Index",
+          "columns": [
+            {
+              "expression": "embedding_1024",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tools_cluster_id_clusters_id_fk": {
+          "name": "tools_cluster_id_clusters_id_fk",
+          "tableFrom": "tools",
+          "tableTo": "clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tools_cluster_id_tools": {
+          "name": "tools_cluster_id_tools",
+          "columns": [
+            "cluster_id",
+            "name"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.versioned_entities": {
+      "name": "versioned_entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "versioned_entities_pkey": {
+          "name": "versioned_entities_pkey",
+          "columns": [
+            "cluster_id",
+            "id",
+            "type",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.workflow_executions": {
+      "name": "workflow_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_execution_id": {
+          "name": "workflow_execution_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "workflow_executions_pkey": {
+          "name": "workflow_executions_pkey",
+          "columns": [
+            "cluster_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/control-plane/drizzle/meta/_journal.json
+++ b/control-plane/drizzle/meta/_journal.json
@@ -1618,6 +1618,13 @@
       "when": 1738880737792,
       "tag": "0231_easy_johnny_blaze",
       "breakpoints": true
+    },
+    {
+      "idx": 232,
+      "version": "7",
+      "when": 1739151138614,
+      "tag": "0232_awesome_tusk",
+      "breakpoints": true
     }
   ]
 }

--- a/control-plane/drizzle/meta/_journal.json
+++ b/control-plane/drizzle/meta/_journal.json
@@ -1622,8 +1622,8 @@
     {
       "idx": 232,
       "version": "7",
-      "when": 1739151138614,
-      "tag": "0232_awesome_tusk",
+      "when": 1739162407596,
+      "tag": "0232_narrow_paper_doll",
       "breakpoints": true
     }
   ]

--- a/control-plane/src/modules/contract.ts
+++ b/control-plane/src/modules/contract.ts
@@ -329,7 +329,7 @@ const RunSchema = z.object({
     .default(false)
     .optional()
     .describe("Enable summarization of oversized call results"),
-  type: z.enum(["simple", "react"]).optional().default("react"),
+  type: z.enum(["single-step", "multi-step"]).optional().default("multi-step"),
   interactive: z
     .boolean()
     .default(true)
@@ -889,7 +889,7 @@ export const definition = {
           name: z.string(),
           userId: z.string().nullable(),
           createdAt: z.date(),
-          type: z.enum(["simple", "react"]),
+          type: z.enum(["single-step", "multi-step"]),
           status: z.enum(["pending", "running", "paused", "done", "failed"]).nullable(),
           test: z.boolean(),
           feedbackScore: z.number().nullable(),
@@ -911,7 +911,7 @@ export const definition = {
       200: z.object({
         id: z.string(),
         userId: z.string().nullable(),
-        type: z.enum(["simple", "react"]).nullable(),
+        type: z.enum(["single-step", "multi-step"]).nullable(),
         status: z.enum(["pending", "running", "paused", "done", "failed"]).nullable(),
         failureReason: z.string().nullable(),
         test: z.boolean(),

--- a/control-plane/src/modules/contract.ts
+++ b/control-plane/src/modules/contract.ts
@@ -329,6 +329,7 @@ const RunSchema = z.object({
     .default(false)
     .optional()
     .describe("Enable summarization of oversized call results"),
+  type: z.enum(["simple", "react"]).optional().default("react"),
   interactive: z
     .boolean()
     .default(true)
@@ -888,6 +889,7 @@ export const definition = {
           name: z.string(),
           userId: z.string().nullable(),
           createdAt: z.date(),
+          type: z.enum(["simple", "react"]),
           status: z.enum(["pending", "running", "paused", "done", "failed"]).nullable(),
           test: z.boolean(),
           feedbackScore: z.number().nullable(),
@@ -909,6 +911,7 @@ export const definition = {
       200: z.object({
         id: z.string(),
         userId: z.string().nullable(),
+        type: z.enum(["simple", "react"]).nullable(),
         status: z.enum(["pending", "running", "paused", "done", "failed"]).nullable(),
         failureReason: z.string().nullable(),
         test: z.boolean(),

--- a/control-plane/src/modules/data.ts
+++ b/control-plane/src/modules/data.ts
@@ -369,6 +369,11 @@ export const runs = pgTable(
     agent_id: varchar("agent_id", { length: 128 }),
     agent_version: integer("agent_version"),
     reasoning_traces: boolean("reasoning_traces").default(true).notNull(),
+    type: text("type", {
+      enum: ["simple", "react"],
+    })
+      .default("react")
+      .notNull(),
     interactive: boolean("interactive").default(true).notNull(),
     enable_summarization: boolean("enable_summarization").default(false).notNull(),
     enable_result_grounding: boolean("enable_result_grounding").default(false).notNull(),

--- a/control-plane/src/modules/data.ts
+++ b/control-plane/src/modules/data.ts
@@ -370,9 +370,9 @@ export const runs = pgTable(
     agent_version: integer("agent_version"),
     reasoning_traces: boolean("reasoning_traces").default(true).notNull(),
     type: text("type", {
-      enum: ["simple", "react"],
+      enum: ["single-step", "multi-step"],
     })
-      .default("react")
+      .default("multi-step")
       .notNull(),
     interactive: boolean("interactive").default(true).notNull(),
     enable_summarization: boolean("enable_summarization").default(false).notNull(),

--- a/control-plane/src/modules/router.ts
+++ b/control-plane/src/modules/router.ts
@@ -139,6 +139,7 @@ export const router = initServer().router(contract, {
         id: run.id,
         userId: run.userId ?? null,
         status: run.status,
+        type: run.type,
         failureReason: run.failureReason ?? null,
         test: run.test ?? false,
         feedbackComment: run.feedbackComment ?? null,
@@ -199,6 +200,7 @@ export const router = initServer().router(contract, {
       initialPrompt: body.initialPrompt,
       systemPrompt: body.systemPrompt,
       attachedFunctions,
+      type: body.type,
       resultSchema: body.resultSchema
         ? (dereferenceSync(body.resultSchema) as JsonSchemaInput)
         : undefined,
@@ -224,6 +226,8 @@ export const router = initServer().router(contract, {
 
       name: body.name,
       tags: body.tags,
+
+      runType: runOptions.type,
 
       // Customer Auth context (In the future all auth types should inject context into the run)
       authContext: customAuth?.context,

--- a/control-plane/src/modules/router.ts
+++ b/control-plane/src/modules/router.ts
@@ -182,6 +182,18 @@ export const router = initServer().router(contract, {
       logger.warn("Using deprecated attachedFunctions field");
     }
 
+    if (body.type === "single-step") {
+      if (body.attachedFunctions || body.tools) {
+        throw new BadRequestError("Single Step runs cannot have attached tools");
+      }
+      if (body.reasoningTraces) {
+        throw new BadRequestError("Single step runs cannot have reasoning traces");
+      }
+      if (body.enableResultGrounding) {
+        throw new BadRequestError("Single step runs cannot have result grounding");
+      }
+    }
+
     if (body.resultSchema) {
       const validationError = validateSchema({
         schema: body.resultSchema,

--- a/control-plane/src/modules/runs/agent/run.test.ts
+++ b/control-plane/src/modules/runs/agent/run.test.ts
@@ -1,4 +1,4 @@
-import { formatJobsContext, processRun } from "./run";
+import { formatJobsContext, processAgentRun } from "./run";
 import { createOwner } from "../../test/util";
 import { ulid } from "ulid";
 import { db, jobs, runs } from "../../data";
@@ -26,6 +26,7 @@ describe("processRun", () => {
       id: Math.random().toString(36).substring(2),
       clusterId: owner.clusterId,
       status: "running" as const,
+      type: "multi-step" as const,
       attachedFunctions: ["someFunction"],
       modelIdentifier: null,
       onStatusChange: {
@@ -94,7 +95,7 @@ describe("processRun", () => {
       }),
     ];
 
-    await processRun(run, undefined, mockModelResponses);
+    await processAgentRun(run, undefined, mockModelResponses);
 
     // Find the Job in the DB
     const onStatusChangeJob = await db

--- a/control-plane/src/modules/runs/agent/run.ts
+++ b/control-plane/src/modules/runs/agent/run.ts
@@ -21,7 +21,7 @@ import { availableTools, getToolDefinition } from "../../tools";
 /**
  * Run a Run from the most recent saved state
  **/
-export const processRun = async (
+export const processAgentRun = async (
   run: {
     id: string;
     clusterId: string;
@@ -32,6 +32,7 @@ export const processRun = async (
     status: string;
     systemPrompt: string | null;
     testMocks: Record<string, { output: Record<string, unknown> }> | null;
+    type: "single-step" | "multi-step";
     test: boolean;
     reasoningTraces: boolean;
     enableResultGrounding: boolean;
@@ -40,10 +41,12 @@ export const processRun = async (
     context: unknown | null;
   },
   tags?: Record<string, string>,
-  mockModelResponses?: string[],
+  mockModelResponses?: string[]
   // Deprecated, to be removed once all SDKs are updated
 ) => {
-  logger.info("Processing Run");
+  logger.info("Processing Run", {
+    type: run.type,
+  });
 
   // Parallelize fetching additional context and service definitions
   const [
@@ -120,9 +123,9 @@ export const processRun = async (
         run: run,
         schema: tool.schema ?? undefined,
         description: tool.description ?? undefined,
-      })
+      });
     },
-    findRelevantTools: (state) => findRelevantTools(state),
+    findRelevantTools: state => findRelevantTools(state),
     postStepSave: async state => {
       logger.debug("Saving run state", {
         runId: run.id,

--- a/control-plane/src/modules/runs/index.ts
+++ b/control-plane/src/modules/runs/index.ts
@@ -55,7 +55,7 @@ export const createRun = async ({
   userId?: string;
   clusterId: string;
   name?: string;
-  runType?: "simple" | "react";
+  runType?: "single-step" | "multi-step";
   systemPrompt?: string;
   test?: boolean;
   testMocks?: Record<
@@ -670,7 +670,7 @@ export type RunOptions = {
   attachedFunctions?: string[];
   resultSchema?: unknown;
 
-  type: "simple" | "react";
+  type: "single-step" | "multi-step";
 
   interactive?: boolean;
   reasoningTraces?: boolean;

--- a/control-plane/src/modules/runs/index.ts
+++ b/control-plane/src/modules/runs/index.ts
@@ -32,6 +32,7 @@ export const createRun = async ({
   userId,
   clusterId,
   name,
+  runType: type,
   test,
   testMocks,
   systemPrompt,
@@ -54,6 +55,7 @@ export const createRun = async ({
   userId?: string;
   clusterId: string;
   name?: string;
+  runType?: "simple" | "react";
   systemPrompt?: string;
   test?: boolean;
   testMocks?: Record<
@@ -100,6 +102,7 @@ export const createRun = async ({
       id: id ?? ulid(),
       cluster_id: clusterId,
       status: "pending",
+      type,
       user_id: userId ?? "SYSTEM",
       ...(name ? { name } : {}),
       debug: sql<boolean>`(SELECT debug FROM ${clusters} WHERE id = ${clusterId})`,
@@ -121,7 +124,8 @@ export const createRun = async ({
       enable_result_grounding: enableResultGrounding,
       // Temporary hack to make the sdk be backwards compatible
       workflow_execution_id: workflowExecutionId ?? tags?.["workflow.executionId"],
-      workflow_version: workflowVersion ?? tags?.["workflow.version"] ? Number(tags?.["workflow.version"]) : null,
+      workflow_version:
+        (workflowVersion ?? tags?.["workflow.version"]) ? Number(tags?.["workflow.version"]) : null,
       workflow_name: workflowName ?? tags?.["workflow.name"],
     })
     .onConflictDoNothing()
@@ -249,6 +253,7 @@ export const getRun = async ({ clusterId, runId }: { clusterId: string; runId: s
       status: runs.status,
       failureReason: runs.failure_reason,
       debug: runs.debug,
+      type: runs.type,
       test: runs.test,
       testMocks: runs.test_mocks,
       onStatusChange: runs.on_status_change,
@@ -292,6 +297,7 @@ export const getClusterRuns = async ({
       createdAt: runs.created_at,
       failureReason: runs.failure_reason,
       debug: runs.debug,
+      type: runs.type,
       test: runs.test,
       feedbackScore: runs.feedback_score,
       modelIdentifier: runs.model_identifier,
@@ -324,6 +330,7 @@ export const getRunDetails = async ({ clusterId, runId }: { clusterId: string; r
         name: runs.name,
         userId: runs.user_id,
         clusterId: runs.cluster_id,
+        type: runs.type,
         status: runs.status,
         systemPrompt: runs.system_prompt,
         failureReason: runs.failure_reason,
@@ -662,6 +669,8 @@ export type RunOptions = {
   systemPrompt?: string;
   attachedFunctions?: string[];
   resultSchema?: unknown;
+
+  type: "simple" | "react";
 
   interactive?: boolean;
   reasoningTraces?: boolean;

--- a/control-plane/src/modules/runs/simple/run.ts
+++ b/control-plane/src/modules/runs/simple/run.ts
@@ -1,0 +1,199 @@
+import { and, eq } from "drizzle-orm";
+import { db, runs } from "../../data";
+import { logger } from "../../observability/logger";
+import { onStatusChangeSchema } from "../../contract";
+import { ChatIdentifiers } from "../../models/routing";
+import { z } from "zod";
+import { buildModel } from "../../models";
+import { addAttributes } from "../../observability/tracer";
+import { getRunMessages, insertRunMessage, toAnthropicMessages } from "../messages";
+import { AgentError, RetryableError } from "../../../utilities/errors";
+import { JsonSchemaInput, validateToolSchema } from "../../tools/validations";
+import { Validator } from "jsonschema";
+import { ulid } from "ulid";
+import { notifyStatusChange } from "../notify";
+import AsyncRetry from "async-retry";
+
+const validator = new Validator();
+
+export const processSimpleRun = async (run: {
+  id: string;
+  clusterId: string;
+  modelIdentifier: ChatIdentifiers | null;
+  resultSchema: unknown | null;
+  type: "single-step" | "multi-step";
+  debug: boolean;
+  status: string;
+  systemPrompt: string | null;
+  onStatusChange: z.infer<typeof onStatusChangeSchema> | null;
+  authContext: unknown | null;
+  context: unknown | null;
+}) => {
+  logger.info("Processing Run", {
+    type: run.type,
+  });
+
+  await db.update(runs).set({ status: "running", failure_reason: "" }).where(eq(runs.id, run.id));
+
+  const model = buildModel({
+    identifier: run.modelIdentifier ?? "claude-3-5-sonnet",
+    purpose: "agent_loop.reasoning",
+    trackingOptions: {
+      clusterId: run.clusterId,
+      runId: run.id,
+    },
+  });
+
+  addAttributes({
+    "model.identifier": model.identifier,
+  });
+
+  const messages = await getRunMessages({
+    clusterId: run.clusterId,
+    runId: run.id,
+  });
+
+  if (run.debug) {
+    addAttributes({
+      "model.input.systemPrompt": run.systemPrompt ?? "",
+      "model.input.messages": JSON.stringify(
+        messages.map(m => ({
+          id: m.id,
+          type: m.type,
+        }))
+      ),
+    });
+  }
+
+  const schema = run.resultSchema ?? {
+    type: "object",
+    properties: {
+      message: { type: "string" },
+    },
+    required: [],
+  };
+
+  const resultSchemaErrors = validateToolSchema(schema as JsonSchemaInput);
+  if (resultSchemaErrors.length > 0) {
+    throw new AgentError("Result schema is not invalid JSONSchema");
+  }
+
+  const attempt = AsyncRetry(
+    async () => {
+      const response = await model.structured({
+        messages: toAnthropicMessages(messages),
+        system: run.systemPrompt ?? "",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        schema: schema as any,
+      });
+
+      if (!response) {
+        throw new AgentError("Model call failed");
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const validation = validator.validate(response.structured, schema as any);
+
+      if (!validation.valid) {
+        logger.warn("Model provided invalid response object", {
+          errors: validation.errors,
+          structured: response.structured,
+          raw: response.raw,
+        });
+
+        const newMessages = [
+          {
+            id: ulid(),
+            type: "agent-invalid" as const,
+            data: {
+              message: "Produced model output",
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              details: response.raw as any,
+            },
+            runId: run.id,
+            clusterId: run.clusterId,
+            createdAt: new Date(),
+          },
+          {
+            id: ulid(),
+            type: "supervisor" as const,
+            data: {
+              message:
+                "You provided an invalid output. Refer to the final_result_schema for the expected format. The validation errors are mentioned below.",
+              details: { errors: validation.errors },
+            },
+            runId: run.id,
+            clusterId: run.clusterId,
+            createdAt: new Date(),
+          },
+        ];
+
+        for (const message of newMessages) {
+          await insertRunMessage(message);
+        }
+
+        throw new AgentError("Model provided invalid response object");
+      }
+      return response;
+    },
+    {
+      retries: 5,
+    }
+  );
+
+  try {
+    const response = await attempt;
+
+    await insertRunMessage({
+      id: ulid(),
+      type: "agent",
+      data: {
+        result: response.structured,
+      },
+      runId: run.id,
+      clusterId: run.clusterId,
+    });
+
+    await db
+      .update(runs)
+      .set({ status: "done" })
+      .where(and(eq(runs.id, run.id), eq(runs.cluster_id, run.clusterId)));
+
+    await notifyStatusChange({
+      run: {
+        id: run.id,
+        clusterId: run.clusterId,
+        onStatusChange: run.onStatusChange,
+        status: run.status,
+        authContext: run.authContext,
+        context: run.context,
+      },
+      status: "done",
+      result: response.structured,
+    });
+  } catch (error) {
+    let reason = "Unknown error";
+    if (error instanceof Error) {
+      reason = error.message;
+    }
+    await db
+      .update(runs)
+      .set({
+        status: "failed",
+        failure_reason: reason,
+      })
+      .where(and(eq(runs.id, run.id), eq(runs.cluster_id, run.clusterId)));
+
+    await notifyStatusChange({
+      run: {
+        id: run.id,
+        clusterId: run.clusterId,
+        onStatusChange: run.onStatusChange,
+        status: run.status,
+        authContext: run.authContext,
+        context: run.context,
+      },
+      status: "failed",
+    });
+  }
+};

--- a/control-plane/src/modules/runs/tags.ts
+++ b/control-plane/src/modules/runs/tags.ts
@@ -12,7 +12,7 @@ export const getRunsByTag = async ({
   key: string;
   value: string;
   limit?: number;
-  userId?: string
+  userId?: string;
 }) => {
   return await db
     .select({
@@ -20,6 +20,7 @@ export const getRunsByTag = async ({
       name: runs.name,
       userId: runs.user_id,
       clusterId: runs.cluster_id,
+      type: runs.type,
       status: runs.status,
       createdAt: runs.created_at,
       failureReason: runs.failure_reason,
@@ -36,39 +37,28 @@ export const getRunsByTag = async ({
         eq(runTags.cluster_id, clusterId),
         eq(runTags.key, key),
         eq(runTags.value, value),
-        ...(userId ? [eq(runs.user_id, userId)] : []),
-      ),
+        ...(userId ? [eq(runs.user_id, userId)] : [])
+      )
     )
     .rightJoin(runs, eq(runTags.run_id, runs.id))
     .orderBy(desc(runs.created_at))
     .limit(limit);
 };
 
-export const getRunTags = async ({
-  clusterId,
-  runId,
-}: {
-  clusterId: string;
-  runId: string;
-}) => {
+export const getRunTags = async ({ clusterId, runId }: { clusterId: string; runId: string }) => {
   const tags = await db
     .select({
       key: runTags.key,
       value: runTags.value,
     })
     .from(runTags)
-    .where(
-      and(
-        eq(runTags.cluster_id, clusterId),
-        eq(runTags.run_id, runId),
-      ),
-    );
+    .where(and(eq(runTags.cluster_id, clusterId), eq(runTags.run_id, runId)));
 
   return tags.reduce(
     (acc, { key, value }) => {
       acc[key] = value;
       return acc;
     },
-    {} as Record<string, string>,
+    {} as Record<string, string>
   );
 };

--- a/sdk-node/src/contract.ts
+++ b/sdk-node/src/contract.ts
@@ -45,7 +45,7 @@ export const VersionedTextsSchema = z.object({
     z.object({
       version: z.string(),
       content: z.string(),
-    }),
+    })
   ),
 });
 
@@ -76,25 +76,17 @@ export const onStatusChangeSchema = z.preprocess(
   z.union([
     z.object({
       type: z.literal("function"),
-      statuses: z.array(
-        z.enum(["pending", "running", "paused", "done", "failed"]),
-      ),
-      function: functionReference.describe(
-        "A function to call when the run status changes",
-      ),
+      statuses: z.array(z.enum(["pending", "running", "paused", "done", "failed"])),
+      function: functionReference.describe("A function to call when the run status changes"),
     }),
     z.object({
       type: z.literal("tool"),
-      statuses: z.array(
-        z.enum(["pending", "running", "paused", "done", "failed"]),
-      ),
+      statuses: z.array(z.enum(["pending", "running", "paused", "done", "failed"])),
       tool: z.string().describe("A tool to call when the run status changes"),
     }),
     z.object({
       type: z.literal("webhook"),
-      statuses: z.array(
-        z.enum(["pending", "running", "paused", "done", "failed"]),
-      ),
+      statuses: z.array(z.enum(["pending", "running", "paused", "done", "failed"])),
       webhook: z
         .string()
         .regex(/^https?:\/\/.+$/)
@@ -102,16 +94,14 @@ export const onStatusChangeSchema = z.preprocess(
     }),
     z.object({
       type: z.literal("workflow"),
-      statuses: z.array(
-        z.enum(["pending", "running", "paused", "done", "failed"]),
-      ),
+      statuses: z.array(z.enum(["pending", "running", "paused", "done", "failed"])),
       workflow: z
         .object({
           executionId: z.string().describe("The execution ID of the workflow"),
         })
         .describe("A workflow to run when the run status changes"),
     }),
-  ]),
+  ])
 );
 
 export const integrationSchema = z.object({
@@ -178,17 +168,13 @@ const resultDataSchema = z
 export const learningSchema = z.object({
   summary: z
     .string()
-    .describe(
-      "The new information that was learned. Be generic, do not refer to the entities.",
-    ),
+    .describe("The new information that was learned. Be generic, do not refer to the entities."),
   entities: z
     .array(
       z.object({
-        name: z
-          .string()
-          .describe("The name of the entity this learning relates to."),
+        name: z.string().describe("The name of the entity this learning relates to."),
         type: z.enum(["tool"]),
-      }),
+      })
     )
     .describe("The entities this learning relates to."),
   relevance: z.object({
@@ -212,7 +198,7 @@ const agentDataSchema = z
           toolName: z.string(),
           reasoning: z.string().optional(),
           input: z.object({}).passthrough(),
-        }),
+        })
       )
       .optional(),
   })
@@ -274,10 +260,7 @@ export type MessageTypes =
   | "supervisor"
   | "agent-invalid";
 
-export type UnifiedMessageOfType<T extends MessageTypes> = Extract<
-  UnifiedMessage,
-  { type: T }
->;
+export type UnifiedMessageOfType<T extends MessageTypes> = Extract<UnifiedMessage, { type: T }>;
 
 export const ToolConfigSchema = z.object({
   cache: z
@@ -296,29 +279,23 @@ const RunSchema = z.object({
     .string()
     .optional()
     .describe(
-      "The run ID. If not provided, a new run will be created. If provided, the run will be created with the given. If the run already exists, it will be returned.",
+      "The run ID. If not provided, a new run will be created. If provided, the run will be created with the given. If the run already exists, it will be returned."
     )
     .refine(
-      (val) => !val || /^[0-9A-Za-z-_.]{4,128}$/.test(val),
-      "Run ID must contain only alphanumeric characters, dashes, underscores, and periods. Must be between 4 and 128 characters long.",
+      val => !val || /^[0-9A-Za-z-_.]{4,128}$/.test(val),
+      "Run ID must contain only alphanumeric characters, dashes, underscores, and periods. Must be between 4 and 128 characters long."
     ),
   runId: z
     .string()
     .optional()
     .describe("Deprecated. Use `id` instead.")
     .refine(
-      (val) => !val || /^[0-9A-Za-z-_.]{4,128}$/.test(val),
-      "Run ID must contain only alphanumeric characters, dashes, underscores, and periods. Must be between 4 and 128 characters long.",
+      val => !val || /^[0-9A-Za-z-_.]{4,128}$/.test(val),
+      "Run ID must contain only alphanumeric characters, dashes, underscores, and periods. Must be between 4 and 128 characters long."
     ),
-  initialPrompt: z
-    .string()
-    .optional()
-    .describe("An initial 'human' message to trigger the run"),
+  initialPrompt: z.string().optional().describe("An initial 'human' message to trigger the run"),
   systemPrompt: z.string().optional().describe("A system prompt for the run."),
-  name: z
-    .string()
-    .optional()
-    .describe("The name of the run, if not provided it will be generated"),
+  name: z.string().optional().describe("The name of the run, if not provided it will be generated"),
   model: z
     .enum(["claude-3-5-sonnet", "claude-3-haiku"])
     .optional()
@@ -326,7 +303,7 @@ const RunSchema = z.object({
   resultSchema: anyObject
     .optional()
     .describe(
-      "A JSON schema definition which the result object should conform to. By default the result will be a JSON object which does not conform to any schema",
+      "A JSON schema definition which the result object should conform to. By default the result will be a JSON object which does not conform to any schema"
     ),
   tools: z
     .array(z.string())
@@ -338,41 +315,26 @@ const RunSchema = z.object({
     .describe("DEPRECATED, use tools instead"),
   onStatusChange: onStatusChangeSchema
     .optional()
-    .describe(
-      "Mechanism for receiving notifications when the run status changes",
-    ),
-  tags: z
-    .record(z.string())
-    .optional()
-    .describe("Run tags which can be used to filter runs"),
+    .describe("Mechanism for receiving notifications when the run status changes"),
+  tags: z.record(z.string()).optional().describe("Run tags which can be used to filter runs"),
   input: z
     .object({})
     .passthrough()
     .describe("Structured input arguments to merge with the initial prompt.")
     .optional(),
-  context: anyObject
-    .optional()
-    .describe("Additional context to propogate to all Jobs in the Run"),
-  reasoningTraces: z
-    .boolean()
-    .default(true)
-    .optional()
-    .describe("Enable reasoning traces"),
+  context: anyObject.optional().describe("Additional context to propogate to all Jobs in the Run"),
+  reasoningTraces: z.boolean().default(true).optional().describe("Enable reasoning traces"),
   callSummarization: z
     .boolean()
     .default(false)
     .optional()
     .describe("Enable summarization of oversized call results"),
+  type: z.enum(["single-step", "multi-step"]).optional().default("multi-step"),
   interactive: z
     .boolean()
     .default(true)
-    .describe(
-      "Allow the run to be continued with follow-up messages / message edits",
-    ),
-  enableResultGrounding: z
-    .boolean()
-    .default(false)
-    .describe("Enable result grounding"),
+    .describe("Allow the run to be continued with follow-up messages / message edits"),
+  enableResultGrounding: z.boolean().default(false).describe("Enable result grounding"),
 });
 
 export const definition = {
@@ -441,9 +403,7 @@ export const definition = {
         .min(0)
         .max(20)
         .default(0)
-        .describe(
-          "Time in seconds to keep the request open waiting for a response",
-        ),
+        .describe("Time in seconds to keep the request open waiting for a response"),
     }),
     headers: z.object({
       authorization: z.string(),
@@ -506,13 +466,8 @@ export const definition = {
     method: "GET",
     path: "/clusters/:clusterId/jobs",
     query: z.object({
-      tools: z
-        .string()
-        .optional()
-        .describe("Comma-separated list of tools to poll"),
-      status: z
-        .enum(["pending", "running", "paused", "done", "failed"])
-        .default("pending"),
+      tools: z.string().optional().describe("Comma-separated list of tools to poll"),
+      status: z.enum(["pending", "running", "paused", "done", "failed"]).default("pending"),
       limit: z.coerce.number().min(1).max(20).default(10),
       acknowledge: z.coerce
         .boolean()
@@ -539,7 +494,7 @@ export const definition = {
           authContext: z.any().nullable(),
           runContext: z.any().nullable(),
           approved: z.boolean(),
-        }),
+        })
       ),
     },
   },
@@ -587,13 +542,11 @@ export const definition = {
         message: z.string(),
       }),
     },
-    body: blobSchema
-      .omit({ id: true, createdAt: true, jobId: true, runId: true })
-      .and(
-        z.object({
-          data: z.string(),
-        }),
-      ),
+    body: blobSchema.omit({ id: true, createdAt: true, jobId: true, runId: true }).and(
+      z.object({
+        data: z.string(),
+      })
+    ),
   },
 
   createMachine: {
@@ -611,7 +564,7 @@ export const definition = {
             description: z.string().optional(),
             schema: z.string().optional(),
             config: ToolConfigSchema.optional(),
-          }),
+          })
         )
         .optional(),
       tools: z
@@ -621,7 +574,7 @@ export const definition = {
             description: z.string().optional(),
             schema: z.string().optional(),
             config: ToolConfigSchema.optional(),
-          }),
+          })
         )
         .optional(),
     }),
@@ -644,13 +597,8 @@ export const definition = {
       204: z.undefined(),
     },
     body: z.object({
-      description: z
-        .string()
-        .describe("Human readable description of the cluster"),
-      name: z
-        .string()
-        .optional()
-        .describe("Human readable name of the cluster"),
+      description: z.string().describe("Human readable description of the cluster"),
+      name: z.string().optional().describe("Human readable name of the cluster"),
       isDemo: z
         .boolean()
         .optional()
@@ -683,13 +631,13 @@ export const definition = {
       name: z.string().optional(),
       description: z.string().optional(),
       additionalContext: VersionedTextsSchema.optional().describe(
-        "Additional cluster context which is included in all runs",
+        "Additional cluster context which is included in all runs"
       ),
       debug: z
         .boolean()
         .optional()
         .describe(
-          "Enable additional logging (Including prompts and results) for use by Inferable support",
+          "Enable additional logging (Including prompts and results) for use by Inferable support"
         ),
       enableCustomAuth: z.boolean().optional(),
       enableKnowledgebase: z.boolean().optional(),
@@ -720,7 +668,7 @@ export const definition = {
             ip: z.string().nullable(),
             sdkVersion: z.string().nullable(),
             sdkLanguage: z.string().nullable(),
-          }),
+          })
         ),
         tools: z.array(
           z.object({
@@ -731,7 +679,7 @@ export const definition = {
             shouldExpire: z.boolean(),
             createdAt: z.number(),
             lastPingAt: z.number().nullable(),
-          }),
+          })
         ),
       }),
       401: z.undefined(),
@@ -754,7 +702,7 @@ export const definition = {
           name: z.string(),
           createdAt: z.date(),
           description: z.string().nullable(),
-        }),
+        })
       ),
       401: z.undefined(),
     },
@@ -813,7 +761,7 @@ export const definition = {
           workflowId: z.string().nullable(),
           meta: z.any().nullable(),
           id: z.string(),
-        }),
+        })
       ),
       401: z.undefined(),
       404: z.undefined(),
@@ -863,13 +811,13 @@ export const definition = {
             totalInputTokens: z.number(),
             totalOutputTokens: z.number(),
             totalModelInvocations: z.number(),
-          }),
+          })
         ),
         runs: z.array(
           z.object({
             date: z.string(),
             totalRuns: z.number(),
-          }),
+          })
         ),
       }),
     },
@@ -929,13 +877,10 @@ export const definition = {
       userId: z.string().optional(),
       test: z.coerce
         .string()
-        .transform((value) => value === "true")
+        .transform(value => value === "true")
         .optional(),
       limit: z.coerce.number().min(10).max(50).default(50),
-      tags: z
-        .string()
-        .optional()
-        .describe("Filter runs by a tag value (value:key)"),
+      tags: z.string().optional().describe("Filter runs by a tag value (value:key)"),
     }),
     responses: {
       200: z.array(
@@ -944,15 +889,14 @@ export const definition = {
           name: z.string(),
           userId: z.string().nullable(),
           createdAt: z.date(),
-          status: z
-            .enum(["pending", "running", "paused", "done", "failed"])
-            .nullable(),
+          type: z.enum(["simple", "agent"]),
+          status: z.enum(["pending", "running", "paused", "done", "failed"]).nullable(),
           test: z.boolean(),
           feedbackScore: z.number().nullable(),
           workflowExecutionId: z.string().nullable(),
           workflowVersion: z.number().nullable(),
           workflowName: z.string().nullable(),
-        }),
+        })
       ),
       401: z.undefined(),
     },
@@ -967,9 +911,8 @@ export const definition = {
       200: z.object({
         id: z.string(),
         userId: z.string().nullable(),
-        status: z
-          .enum(["pending", "running", "paused", "done", "failed"])
-          .nullable(),
+        type: z.enum(["simple", "agent"]).nullable(),
+        status: z.enum(["pending", "running", "paused", "done", "failed"]).nullable(),
         failureReason: z.string().nullable(),
         test: z.boolean(),
         feedbackComment: z.string().nullable(),
@@ -991,12 +934,7 @@ export const definition = {
     }),
     body: z.object({
       comment: z.string().describe("Feedback comment").nullable(),
-      score: z
-        .number()
-        .describe("Score between 0 and 1")
-        .min(0)
-        .max(1)
-        .nullable(),
+      score: z.number().describe("Score between 0 and 1").min(0).max(1).nullable(),
     }),
     responses: {
       204: z.undefined(),
@@ -1052,9 +990,7 @@ export const definition = {
         .min(0)
         .max(20)
         .default(0)
-        .describe(
-          "Time in seconds to keep the request open waiting for a response",
-        ),
+        .describe("Time in seconds to keep the request open waiting for a response"),
       after: z.string().default("0"),
       limit: z.coerce.number().min(10).max(50).default(50),
     }),
@@ -1097,7 +1033,7 @@ export const definition = {
           createdAt: z.date(),
           createdBy: z.string(),
           revokedAt: z.date().nullable(),
-        }),
+        })
       ),
     },
   },
@@ -1130,7 +1066,7 @@ export const definition = {
           id: z.string(),
           lastPingAt: z.date(),
           ip: z.string(),
-        }),
+        })
       ),
     },
     pathParams: z.object({
@@ -1161,7 +1097,7 @@ export const definition = {
             createdAt: z.date(),
             jobId: z.string().nullable(),
             targetFn: z.string().nullable(),
-          }),
+          })
         ),
         jobs: z.array(
           z.object({
@@ -1172,14 +1108,12 @@ export const definition = {
             createdAt: z.date(),
             approved: z.boolean().nullable(),
             approvalRequested: z.boolean().nullable(),
-          }),
+          })
         ),
         run: z.object({
           id: z.string(),
           userId: z.string().nullable(),
-          status: z
-            .enum(["pending", "running", "paused", "done", "failed"])
-            .nullable(),
+          status: z.enum(["pending", "running", "paused", "done", "failed"]).nullable(),
           failureReason: z.string().nullable(),
           test: z.boolean(),
           context: z.any().nullable(),
@@ -1283,14 +1217,14 @@ export const definition = {
             resultType: z.string().nullable(),
             status: z.string().nullable(),
             workflowId: z.string().nullable(),
-          }),
+          })
         ),
         associatedRuns: z.array(
           z.object({
             id: z.string(),
             status: z.string(),
             createdAt: z.date(),
-          }),
+          })
         ),
         runEvents: z.array(
           z.object({
@@ -1304,7 +1238,7 @@ export const definition = {
             resultType: z.string().nullable(),
             status: z.string().nullable(),
             workflowId: z.string().nullable(),
-          }),
+          })
         ),
       }),
     },
@@ -1360,7 +1294,7 @@ export const definition = {
           shouldExpire: z.boolean(),
           lastPingAt: z.date().nullable(),
           createdAt: z.date(),
-        }),
+        })
       ),
       401: z.undefined(),
     },

--- a/sdk-node/src/workflows/workflow.ts
+++ b/sdk-node/src/workflows/workflow.ts
@@ -31,6 +31,7 @@ type WorkflowConfig<TInput extends WorkflowInput, name extends string> = {
 type AgentConfig<TResult> = {
   name: string;
   systemPrompt?: string;
+  type?: "single-step" | "multi-step";
   tools?: string[];
   resultSchema?: z.ZodType<TResult>;
   runId?: string;
@@ -310,6 +311,7 @@ export class Workflow<TInput extends WorkflowInput, name extends string> {
               body: {
                 name: `${this.name}_${config.name}`,
                 id: runId,
+                type: config.type || "multi-step",
                 systemPrompt: config.systemPrompt,
                 resultSchema,
                 tools: config.tools,
@@ -330,7 +332,7 @@ export class Workflow<TInput extends WorkflowInput, name extends string> {
               },
             });
 
-            this.logger?.info("Agent run completed", {
+            this.logger?.info("Agent run created", {
               version,
               name: this.name,
               executionId,


### PR DESCRIPTION
Adds a new field to `createRun`, `type=simple|agent` which specifies if a run should be multi-step (agent) or not.

```ts
  const simpleCall = ctx.agent({
    name: "test",
    type: "simple",
    systemPrompt: "Return the word, needle.",
    resultSchema: z.object({
      word: z.string(),
    }),
  });

  const simpleResult = await simpleCall.trigger({
    data: {},
  });
```