### PR TITLE
chore: Support general interrupt type

### DIFF
--- a/control-plane/src/modules/auth/custom.ts
+++ b/control-plane/src/modules/auth/custom.ts
@@ -9,7 +9,7 @@ import { z } from "zod";
 import { getToolDefinition } from "../tools";
 
 const customAuthContextCache = createCache<{
-  status: "pending" | "running" | "success" | "failure" | "stalled";
+  status: "pending" | "running" | "success" | "failure" | "stalled" | "interrupted";
   result: string | null;
   resultType: jobs.ResultType | null;
 }>(Symbol("customAuthContextCache"));

--- a/control-plane/src/modules/contract.ts
+++ b/control-plane/src/modules/contract.ts
@@ -419,7 +419,7 @@ export const definition = {
         id: z.string(),
         result: z.any().nullable(),
         resultType: z.enum(["resolution", "rejection", "interrupt"]).nullable(),
-        status: z.enum(["pending", "running", "success", "failure", "stalled"]),
+        status: z.enum(["pending", "running", "success", "failure", "stalled", "interrupted"]),
       }),
     },
   },

--- a/control-plane/src/modules/data.ts
+++ b/control-plane/src/modules/data.ts
@@ -73,7 +73,7 @@ export const jobs = pgTable(
     target_args: text("target_args").notNull(),
     cache_key: varchar("cache_key", { length: 1024 }),
     status: text("status", {
-      enum: ["pending", "running", "success", "failure", "stalled"], // job failure is actually a stalled state. TODO: rename it
+      enum: ["pending", "running", "success", "failure", "stalled", "interrupted"], // job failure is actually a stalled state. TODO: rename it
     }).notNull(),
     result: text("result"),
     result_type: text("result_type", {

--- a/control-plane/src/modules/jobs/jobs.test.ts
+++ b/control-plane/src/modules/jobs/jobs.test.ts
@@ -143,7 +143,7 @@ describe("selfHealCalls", () => {
       clusterId: owner.clusterId,
     });
 
-    expect(job!.status).toBe("pending");
+    expect(job!.status).toBe("interrupted");
   });
 
   it("should not retry a job that has reached max attempts", async () => {

--- a/control-plane/src/modules/jobs/jobs.ts
+++ b/control-plane/src/modules/jobs/jobs.ts
@@ -26,7 +26,7 @@ export const getJobStatusSync = async ({
 }) => {
   let jobResult:
     | {
-        status: "pending" | "running" | "success" | "failure" | "stalled";
+        status: "pending" | "running" | "success" | "failure" | "stalled" | "interrupted";
         result: string | null;
         resultType: ResultType | null;
       }
@@ -289,11 +289,21 @@ export const pollJobsByTools = async ({
   return jobs;
 };
 
+export async function generalInterrupt({ jobId, clusterId }: { jobId: string; clusterId: string }) {
+  await data.db
+    .update(data.jobs)
+    .set({
+      status: "interrupted",
+    })
+    .where(and(eq(data.jobs.id, jobId), eq(data.jobs.cluster_id, clusterId)));
+}
+
 export async function requestApproval({ jobId, clusterId }: { jobId: string; clusterId: string }) {
   const [updated] = await data.db
     .update(data.jobs)
     .set({
       approval_requested: true,
+      status: "interrupted",
     })
     .returning({
       jobId: data.jobs.id,

--- a/control-plane/src/modules/router.ts
+++ b/control-plane/src/modules/router.ts
@@ -682,14 +682,17 @@ export const router = initServer().router(contract, {
           jobId,
           clusterId,
         });
-
-        return {
-          status: 204,
-          body: undefined,
-        };
       } else {
-        throw new BadRequestError("Unsupported interrupt type");
+        await jobs.generalInterrupt({
+          jobId,
+          clusterId,
+        });
       }
+
+      return {
+        status: 204,
+        body: undefined,
+      };
     }
 
     if (!!result) {

--- a/sdk-node/src/util.ts
+++ b/sdk-node/src/util.ts
@@ -278,7 +278,7 @@ export const blob = ({
 };
 
 export const INTERRUPT_KEY = "__inferable_interrupt";
-type VALID_INTERRUPT_TYPES = "approval";
+type VALID_INTERRUPT_TYPES = "approval" | "general";
 const interruptResultSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("approval"),
@@ -314,5 +314,9 @@ export class Interrupt {
 
   static approval() {
     return new Interrupt("approval");
+  }
+
+  static general() {
+    return new Interrupt("general");
   }
 }


### PR DESCRIPTION
Support for `general` Interrupt type from jobs which will pause without creating an approval request.