### PR TITLE
fix: Handle workflow pause using interrupts

### DIFF
--- a/control-plane/src/modules/contract.ts
+++ b/control-plane/src/modules/contract.ts
@@ -21,7 +21,7 @@ const anyObject = z.object({}).passthrough();
 
 export const interruptSchema = z.discriminatedUnion("type", [
   z.object({
-    type: z.literal("approval"),
+    type: z.enum(["approval", "general"]),
   }),
 ]);
 

--- a/sdk-node/src/util.ts
+++ b/sdk-node/src/util.ts
@@ -281,7 +281,7 @@ export const INTERRUPT_KEY = "__inferable_interrupt";
 type VALID_INTERRUPT_TYPES = "approval" | "general";
 const interruptResultSchema = z.discriminatedUnion("type", [
   z.object({
-    type: z.literal("approval"),
+    type: z.enum(["approval", "general"]),
   }),
 ]);
 

--- a/sdk-node/src/workflows/workflow.test.ts
+++ b/sdk-node/src/workflows/workflow.test.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { Inferable } from "../Inferable";
 import { getEphemeralSetup } from "./workflow-test-utils";
 import { helpers } from "./workflow";
+import { Interrupt } from "../util";
 
 describe("workflow", () => {
   it("should run a workflow", async () => {

--- a/sdk-node/src/workflows/workflow.ts
+++ b/sdk-node/src/workflows/workflow.ts
@@ -393,11 +393,12 @@ export class Workflow<TInput extends WorkflowInput, name extends string> {
           }
           const ctx = this.createContext(version, input.executionId, input);
           try {
-            return handler(ctx, input);
+            return await handler(ctx, input);
           } catch (e) {
             if (e instanceof WorkflowPausableError) {
               return Interrupt.general();
             }
+            throw e;
           }
         },
         name: `workflows_${this.name}_${version}`,


### PR DESCRIPTION
Rather than marking a workflow as `failed`, return an `interrupt` object which will pause the job.

This will allow us to monitor the status of a Workflow (Success, failure, etc) by tracking the underlying workflow's job.