### PR TITLE
chore: Add pgsql-adapter image health-check

### DIFF
--- a/adapters/pgsql-adapter/Dockerfile
+++ b/adapters/pgsql-adapter/Dockerfile
@@ -3,11 +3,15 @@ FROM node:20-alpine
 WORKDIR /app
 
 # Pre-install pgsql-adapter globally
-RUN npm install -g @inferable/pgsql-adapter@latest
+RUN npm install -g @inferable/pgsql-adapter@0.0.8
 
 # Entrypoint script to handle environment variables
 COPY docker-entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+# Add health-check script
+COPY health-check.sh /usr/local/bin/health-check
+RUN chmod +x /usr/local/bin/health-check
 
 RUN addgroup -S inferable && adduser -S inferable -G inferable
 USER inferable

--- a/adapters/pgsql-adapter/README.md
+++ b/adapters/pgsql-adapter/README.md
@@ -38,10 +38,19 @@ Options:
       --schema        Database schema to use        [string] [default: "public"]
       --secret        Inferable API cluster secret                      [string]
       --endpoint      Inferable API endpoint                            [string]
+      --test          Test the Database connection and exit             [boolean]
   -h, --help          Show help                                        [boolean]
+
+Commands:
 ```
 
 **Examples**
+
+- Test database connection:
+
+```bash
+npx @inferable/pgsql-adapter postgresql://user:pass@localhost:5432/postgres test
+```
 
 - Prompt human approval on all workflows:
 
@@ -67,12 +76,26 @@ npx @inferable/pgsql-adapter postgresql://user:pass@localhost:5432/postgres \
    --secret=sk_inf_xxx
 ```
 
-### Docker Usage for
+### Docker Usage
 
 ```bash
 docker run -e CONNECTION_STRING=postgresql://user:pass@localhost:5432/postgres \
            -e SECRET=sk_inf_xxx \
            inferable/pgsql-adapter
+```
+
+#### Health Checks
+
+For container orchestration platforms like ECS, Kubernetes, or Docker Swarm, the adapter provides a built-in health-check command which will validate the database connection healthjk:
+
+```bash
+# Example ECS task definition health check
+"healthCheck": {
+  "command": [
+    "CMD-SHELL",
+    "health-check || exit 1"
+  ],
+}
 ```
 
 #### Configuration Options

--- a/adapters/pgsql-adapter/docker-entrypoint.sh
+++ b/adapters/pgsql-adapter/docker-entrypoint.sh
@@ -21,7 +21,7 @@ if [ -z "$SECRET" ]; then
 fi
 
 # Construct CLI command with environment variables
-COMMAND="npx --yes @inferable/pgsql-adapter@latest $CONNECTION_STRING \
+COMMAND="pgsql-adapter $CONNECTION_STRING \
     --approval-mode=$APPROVAL_MODE \
     --schema=$SCHEMA \
     --secret=$SECRET"

--- a/adapters/pgsql-adapter/health-check.sh
+++ b/adapters/pgsql-adapter/health-check.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+echo "Running health check"
+
+# Check if required environment variables are set
+if [ -z "$CONNECTION_STRING" ]; then
+    echo "Error: CONNECTION_STRING environment variable is required for health check"
+    exit 1
+fi
+
+if [ -z "$SECRET" ]; then
+    echo "Error: SECRET environment variable is required for health check"
+    exit 1
+fi
+
+# Perform the connection test
+pgsql-adapter "$CONNECTION_STRING" --secret="$SECRET" --test

--- a/adapters/pgsql-adapter/package.json
+++ b/adapters/pgsql-adapter/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@inferable/pgsql-adapter",
-  "version": "0.0.6",
+  "version": "0.0.8",
   "main": "bin/index.js",
   "types": "bin/index.d.ts",
   "bin": {
-    "@inferable/pgsql-adapter": "bin/index.js"
+    "pgsql-adapter": "bin/index.js"
   },
   "scripts": {
     "start": "tsx src/index.ts",

--- a/adapters/pgsql-adapter/src/index.ts
+++ b/adapters/pgsql-adapter/src/index.ts
@@ -2,8 +2,9 @@
 
 import { Inferable } from "inferable";
 import { InferablePGSQLAdapter } from "./postgres/postgres";
-import yargs from "yargs";
+import yargs, { describe } from "yargs";
 import { hideBin } from "yargs/helpers";
+import pg from "pg";
 
 // Export the adapter for library usage
 export { InferablePGSQLAdapter };
@@ -44,6 +45,11 @@ if (require.main === module) {
         type: "string",
         describe: "Inferable API endpoint",
       })
+      .options("test", {
+        describe: "Check that the connection string is valid and exit",
+        type: "boolean",
+        default: false,
+      })
       .help()
       .alias("help", "h").argv;
 
@@ -51,6 +57,7 @@ if (require.main === module) {
       const {
         "approval-mode": approvalMode,
         "privacy-mode": privacyMode,
+        test,
         schema,
         endpoint,
         secret,
@@ -75,6 +82,12 @@ if (require.main === module) {
       });
 
       await adapter.initialize();
+
+      if (test) {
+        console.log("Connection test successful");
+        process.exit(0);
+      }
+
       adapter.register(client);
 
       client.tools.listen();


### PR DESCRIPTION
Adds a `--test` flag to the `pgsql-adapter` script which is also used within the `health-check` command for the docker image.