### PR TITLE
chore: Remove unused workflow trigger fn

### DIFF
--- a/sdk-node/src/workflows/workflow.ts
+++ b/sdk-node/src/workflows/workflow.ts
@@ -118,42 +118,6 @@ export class Workflow<TInput extends WorkflowInput, name extends string> {
         });
         this.versionHandlers.set(version, handler);
       },
-      run: async (input: TInput) => {
-        this.logger?.info("Running workflow", {
-          version,
-          name: this.name,
-          executionId: input.executionId,
-        });
-
-        try {
-          const result = await this.client.createWorkflowExecution({
-            params: {
-              clusterId: await this.getClusterId(),
-              workflowName: this.name,
-            },
-            body: {
-              executionId: input.executionId,
-            },
-          });
-
-          this.logger?.info("Workflow execution created", {
-            version,
-            name: this.name,
-            executionId: input.executionId,
-            status: result.status,
-          });
-
-          return result;
-        } catch (error) {
-          this.logger?.error("Failed to create workflow execution", {
-            version,
-            name: this.name,
-            executionId: input.executionId,
-            error,
-          });
-          throw error;
-        }
-      },
     };
   }
 


### PR DESCRIPTION
The docs reference the following method for triggering workflows:
```
await inferable.workflows.trigger("riskAnalysis", {
  executionId: "123",
  customerId: "456",
});
```

We also expose the following:
```
inferable.workflows.create(xxx).run()
```

This PR removes the second one for now.