### PR TITLE
feat: Add resultType to invocation-result messages

### DIFF
--- a/app/client/contract.ts
+++ b/app/client/contract.ts
@@ -160,7 +160,8 @@ const genericMessageDataSchema = z
 const resultDataSchema = z
   .object({
     id: z.string(),
-    toolName: z.string().optional(),
+    toolName: z.string(),
+    resultType: z.enum(["resolution", "rejection"]),
     result: z.object({}).passthrough(),
   })
   .strict();

--- a/control-plane/src/modules/contract.ts
+++ b/control-plane/src/modules/contract.ts
@@ -160,7 +160,8 @@ const genericMessageDataSchema = z
 const resultDataSchema = z
   .object({
     id: z.string(),
-    toolName: z.string().optional(),
+    toolName: z.string(),
+    resultType: z.enum(["resolution", "rejection"]),
     result: z.object({}).passthrough(),
   })
   .strict();

--- a/control-plane/src/modules/runs/agent/nodes/edges.test.ts
+++ b/control-plane/src/modules/runs/agent/nodes/edges.test.ts
@@ -102,6 +102,8 @@ describe("postStartEdge", () => {
           type: "invocation-result" as const,
           data: {
             id: "456",
+            toolName: "console_echo",
+            resultType: "resolution",
             result: { output: "world" },
           },
           runId: baseState.run.id,
@@ -149,6 +151,8 @@ describe("postStartEdge", () => {
           type: "invocation-result" as const,
           data: {
             id: "456",
+            toolName: "console_echo",
+            resultType: "resolution",
             result: { output: "world" },
           },
           runId: baseState.run.id,
@@ -159,6 +163,8 @@ describe("postStartEdge", () => {
           type: "invocation-result" as const,
           data: {
             id: "123",
+            toolName: "console_echo",
+            resultType: "resolution",
             result: { output: "hello" },
           },
           runId: baseState.run.id,
@@ -200,6 +206,8 @@ describe("postStartEdge", () => {
           type: "invocation-result" as const,
           data: {
             id: "123",
+            toolName: "console_echo",
+            resultType: "resolution",
             result: { output: "hello" },
           },
           runId: baseState.run.id,

--- a/control-plane/src/modules/runs/agent/nodes/tool-call.test.ts
+++ b/control-plane/src/modules/runs/agent/nodes/tool-call.test.ts
@@ -229,9 +229,10 @@ describe("handleToolCalls", () => {
         {
           id: ulid(),
           type: "invocation-result" as const,
-          message: "",
           data: {
             id: "456",
+            toolName: "console_echo",
+            resultType: "resolution" as const,
             result: { output: "world" },
           },
           runId: run.id,

--- a/control-plane/src/modules/runs/agent/nodes/tool-call.ts
+++ b/control-plane/src/modules/runs/agent/nodes/tool-call.ts
@@ -156,6 +156,7 @@ const _handleToolCall = async (
           id: ulid(),
           type: "invocation-result" as const,
           data: {
+            resultType: "rejection",
             result: {
               message: `Failed to find tool: ${toolName}. This might mean that the service that provides this tool is down. Human must be prompted to ask the devs whether to tool "toolName" is connected.`,
               error,
@@ -230,6 +231,7 @@ const _handleToolCall = async (
             id: ulid(),
             type: "invocation-result",
             data: {
+              resultType: "rejection",
               result: {
                 [toolCallId]: response,
               },
@@ -274,6 +276,7 @@ const _handleToolCall = async (
             id: ulid(),
             type: "invocation-result",
             data: {
+              resultType: "resolution",
               result: {
                 [toolCallId]: response,
               },
@@ -326,6 +329,7 @@ const _handleToolCall = async (
             id: ulid(),
             type: "invocation-result",
             data: {
+              resultType: "rejection",
               result: {
                 message: `Provided input did not match schema for ${toolName}, check your input`,
                 parseResult: error.validatorResult.errors,
@@ -375,6 +379,7 @@ const _handleToolCall = async (
           id: ulid(),
           type: "invocation-result",
           data: {
+            resultType: "rejection",
             result: {
               message: `Failed to invoke ${toolName}`,
               error,

--- a/control-plane/src/modules/runs/index.test.ts
+++ b/control-plane/src/modules/runs/index.test.ts
@@ -164,6 +164,8 @@ describe("assertRunReady", () => {
     {
       data: {
         id: "some-id",
+        toolName: "console_echo",
+        resultType: "resolution",
         result: {
           data: "some tool message",
         },

--- a/control-plane/src/modules/runs/messages.ts
+++ b/control-plane/src/modules/runs/messages.ts
@@ -102,10 +102,26 @@ export const getRunMessagesForDisplay = async ({
       if ((message as any).type === "result") {
         message.type = "invocation-result";
       }
+
+      // Handle invocation-result messages before resutlType and toolName were added
+      if (message.type === "invocation-result") {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        if ('resultType' ! in (message.data as any)) {
+          (message.data as any).resultType = "resolution";
+        }
+
+        if ('toolName' ! in (message.data as any)) {
+          // Intentionally setting this to a "falsy" value as it will calculated below
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (message.data as any).toolName = "";
+        }
+      }
+
       if (message.type === "agent") {
         // handle result messages before they were renamed
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         if ((message.data as any).summary) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (message.data as any).message = (message.data as any).summary;
           delete (message.data as any).summary;
         }


### PR DESCRIPTION
Adds `resultType` to `invocation-result` message for easier FE type mapping.

```
 "type": "invocation-result",
  "data": {
      "id": "01JM1B1GH281909R36ZS4YSE6F",
      "toolName": "currentDateTime",
      "resultType": "resolution",
      "result": {
          "iso8601": "2025-02-14T04:21:33.367Z",
          "unix": 1739506893367
      }
  },
  "id": "01JM1B1GHQWB74FQDHCJG15FN0",
  "createdAt": "2025-02-14T04:21:33.369Z",
  "metadata": null
```