### PR TITLE
fix: Only accept interrupt for claimed jobs

### DIFF
--- a/control-plane/src/modules/jobs/jobs.test.ts
+++ b/control-plane/src/modules/jobs/jobs.test.ts
@@ -123,9 +123,16 @@ describe("selfHealCalls", () => {
     expect(createJobResult.id).toBeDefined();
     expect(createJobResult.created).toBe(true);
 
+    await acknowledgeJob({
+      jobId: createJobResult.id,
+      clusterId: owner.clusterId,
+      machineId: "testMachineId",
+    });
+
     await requestApproval({
       jobId: createJobResult.id,
       clusterId: owner.clusterId,
+      machineId: "testMachineId",
     });
 
     // wait for the job to timeout
@@ -386,9 +393,16 @@ describe("submitApproval", () => {
     expect(result.id).toBeDefined();
     expect(result.created).toBe(true);
 
+    await acknowledgeJob({
+      jobId: result.id,
+      clusterId: owner.clusterId,
+      machineId: "testMachineId",
+    })
+
     await requestApproval({
       clusterId: owner.clusterId,
       jobId: result.id,
+      machineId: "testMachineId",
     });
 
     const retreivedJob1 = await getJob({
@@ -441,9 +455,16 @@ describe("submitApproval", () => {
     expect(result.id).toBeDefined();
     expect(result.created).toBe(true);
 
+    await acknowledgeJob({
+      jobId: result.id,
+      clusterId: owner.clusterId,
+      machineId: "testMachineId",
+    })
+
     await requestApproval({
       clusterId: owner.clusterId,
       jobId: result.id,
+      machineId: "testMachineId",
     });
 
     const retreivedJob1 = await getJob({

--- a/control-plane/src/modules/router.ts
+++ b/control-plane/src/modules/router.ts
@@ -43,6 +43,7 @@ import { getRunsByTag } from "./runs/tags";
 import { timeline } from "./timeline";
 import { getWorkflowTools, listTools, recordPoll, upsertToolDefinition } from "./tools";
 import { createWorkflowExecution, listWorkflowExecutions, getWorkflowExecutionTimeline } from "./workflows/executions";
+import { persistJobInterrupt } from "./jobs/job-results";
 
 const readFile = util.promisify(fs.readFile);
 
@@ -684,12 +685,14 @@ export const router = initServer().router(contract, {
           jobId,
           clusterId,
           notification: parsed.data.notification,
+          machineId,
         });
       } else {
         // TODO: Should general interrupts allow notification?
-        await jobs.generalInterrupt({
+        await persistJobInterrupt({
           jobId,
           clusterId,
+          machineId,
         });
       }
 

--- a/control-plane/src/modules/runs/notify.ts
+++ b/control-plane/src/modules/runs/notify.ts
@@ -207,9 +207,15 @@ export const notifyStatusChange = async ({
       id: onStatusChangeDefinition.workflow.executionId,
     });
 
-    logger.info("Resumed workflow execution", {
-      jobId,
-    });
+    if (jobId) {
+      logger.info("Resumed workflow execution", {
+        jobId,
+      });
+    } else {
+      logger.warn("Failed to resume workflow execution", {
+        workflowExecutionId: onStatusChangeDefinition.workflow.executionId,
+      });
+    }
   } else {
     throw new Error(`Unknown onStatusChange type: ${JSON.stringify(onStatusChangeDefinition)}`);
   }


### PR DESCRIPTION
As with [persisting Job Results](https://github.com/inferablehq/inferable/blob/e77bf6191eb300cb7dcf3ae9a0aa227a2b1bcf96/control-plane/src/modules/jobs/job-results.ts#L85), only allow an interrupt (Including approval) to be recorded in the Job is `running` and the interrupt is being submitted by the same `machineId`.