### PR TITLE
feat: Allow tool config to be passed to workflow registration

### DIFF
--- a/sdk-node/src/workflows/demo.ts
+++ b/sdk-node/src/workflows/demo.ts
@@ -37,7 +37,7 @@ import { helpers } from "./workflow";
     }),
   });
 
-  workflow.version(1).define(async (ctx, input) => {
+  workflow.version(1).define(async (input, ctx) => {
     const recordsAgent = ctx.agent({
       name: "recordsAgent",
       systemPrompt: helpers.structuredPrompt({

--- a/sdk-node/src/workflows/workflow.test.ts
+++ b/sdk-node/src/workflows/workflow.test.ts
@@ -31,7 +31,7 @@ describe("workflow", () => {
       }),
     });
 
-    workflow.version(1).define(async (ctx, input) => {
+    workflow.version(1).define(async (input, ctx) => {
       onStart(input);
       const searchAgent = ctx.agent({
         name: "search",


### PR DESCRIPTION
Allow [retryCountOnStall or timeoutSeconds config](https://docs.inferable.ai/pages/tool-configuration#config-object) to be set when registering workflows.