### PR TITLE
chore: Restore documented workflow handle signature

### DIFF
--- a/sdk-node/src/workflows/demo.ts
+++ b/sdk-node/src/workflows/demo.ts
@@ -37,7 +37,7 @@ import { helpers } from "./workflow";
     }),
   });
 
-  workflow.version(1).define(async (input, ctx) => {
+  workflow.version(1).define(async (ctx, input) => {
     const recordsAgent = ctx.agent({
       name: "recordsAgent",
       systemPrompt: helpers.structuredPrompt({

--- a/sdk-node/src/workflows/workflow.test.ts
+++ b/sdk-node/src/workflows/workflow.test.ts
@@ -31,7 +31,7 @@ describe("workflow", () => {
       }),
     });
 
-    workflow.version(1).define(async (input, ctx) => {
+    workflow.version(1).define(async (ctx, input) => {
       onStart(input);
       const searchAgent = ctx.agent({
         name: "search",

--- a/sdk-node/src/workflows/workflow.ts
+++ b/sdk-node/src/workflows/workflow.ts
@@ -7,6 +7,7 @@ import { createApiClient } from "../create-client";
 import { PollingAgent } from "../polling";
 import { JobContext, ToolRegistrationInput } from "../types";
 import { Interrupt } from "../util";
+import { ToolConfigSchema } from "../contract";
 
 type WorkflowInput = {
   executionId: string;
@@ -24,6 +25,7 @@ type WorkflowConfig<TInput extends WorkflowInput, name extends string> = {
   inputSchema: z.ZodType<TInput>;
   logger?: Logger;
   client: ReturnType<typeof createApiClient>;
+  config?: z.infer<typeof ToolConfigSchema>;
   getClusterId: () => Promise<string>;
   endpoint: string;
   machineId: string;
@@ -92,6 +94,7 @@ export class Workflow<TInput extends WorkflowInput, name extends string> {
   private getClusterId: () => Promise<string>;
   private client: ReturnType<typeof createApiClient>;
   private logger?: Logger;
+  private config?: z.infer<typeof ToolConfigSchema>;
 
   private endpoint: string;
   private machineId: string;
@@ -108,6 +111,7 @@ export class Workflow<TInput extends WorkflowInput, name extends string> {
     this.endpoint = config.endpoint;
     this.machineId = config.machineId;
     this.apiSecret = config.apiSecret;
+    this.config = config.config;
   }
 
   version(version: number) {
@@ -376,6 +380,7 @@ export class Workflow<TInput extends WorkflowInput, name extends string> {
           input: this.inputSchema,
         },
         config: {
+          ...this.config,
           private: true,
         },
       });


### PR DESCRIPTION
Update the workflow register function to reflect the docs: `define(input, ctx)` -> `define(ctx, input)`