### PR TITLE
feat: Implement hanging interrupt recovery

### DIFF
--- a/control-plane/src/modules/jobs/job-results.ts
+++ b/control-plane/src/modules/jobs/job-results.ts
@@ -75,7 +75,8 @@ export async function persistJobInterrupt({
     .update(data.jobs)
     .set({
       status: "interrupted",
-      approval_requested: approvalRequested
+      approval_requested: approvalRequested,
+      updated_at: sql`now()`
     })
     .where(
       and(


### PR DESCRIPTION
We have an intermittent issue with interrupted jobs (Workflow Executions) not being resumed correctly.

This PR introduces a recovery mechanism that will catch jobs that meet the following criteria:
- `status: interrupted`
- `last_updated_at : > 1 hour ago && < 5m ago`
- `approval_requested: false`

This is obviously a bit of a work around, I am `WARN` logging on each recovered job so we can try and debug the root cause.