### PR TITLE
feat: Workflow load / e2e test case

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
     paths:
-      - 'load-tests/**'
+      - "load-tests/**"
 
 jobs:
   run-e2e:
@@ -28,7 +28,12 @@ jobs:
       - uses: grafana/setup-k6-action@v1
       - uses: grafana/run-k6-action@v1
         with:
-          path: ./load-tests/script.js
+          path: ./load-tests/run.js
+          fail-fast: true
+          flags: --throw
+      - uses: grafana/run-k6-action@v1
+        with:
+          path: ./load-tests/workflow.js
           fail-fast: true
           flags: --throw
       - run: curl -X POST ${BETTER_STACK_SYNTHETIC_ENDPOINT}

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -16,5 +16,8 @@ npm run machine:start
 
 2. In a new terminal, run the k6 tests:
 ```bash
-npm run test:start
+// Test a run with tool call
+npm run test:start:run
+// Test a workflow (Which it self triggers a run with tool call)
+npm run test:start:workflow
 ```

--- a/load-tests/package-lock.json
+++ b/load-tests/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "inferable": "^0.30.94"
+        "inferable": "^0.30.107",
+        "zod": "^3.24.2"
       },
       "devDependencies": {
         "@types/node": "^22.10.1",
@@ -604,9 +605,9 @@
       }
     },
     "node_modules/inferable": {
-      "version": "0.30.94",
-      "resolved": "https://registry.npmjs.org/inferable/-/inferable-0.30.94.tgz",
-      "integrity": "sha512-rBtdLcEMD38fFn0Bnw9YdUt4UEOr+8qN/f7dy9/LU+0hJjutKxvbHYUefaTr3XqOX49hm17Xsh4WOAqZZ55fZw==",
+      "version": "0.30.107",
+      "resolved": "https://registry.npmjs.org/inferable/-/inferable-0.30.107.tgz",
+      "integrity": "sha512-U1WS3ETskfG/MaNTZWO4SelprVQhpLTURa9mzoXFFC+9edFH+TJoGMXncQ+XjqdO1IRTFKa6bg053O4evSXxaw==",
       "license": "MIT",
       "dependencies": {
         "@ts-rest/core": "^3.28.0",
@@ -701,9 +702,9 @@
       "license": "MIT"
     },
     "node_modules/zod": {
-      "version": "3.23.8",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
-      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "version": "3.24.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
+      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/load-tests/package.json
+++ b/load-tests/package.json
@@ -5,12 +5,14 @@
   "main": "script.js",
   "license": "MIT",
   "scripts": {
-    "test:start": "k6 run script.js",
+    "test:start:run": "k6 run run.js",
+    "test:start:workflow": "k6 run workflow.js",
     "machine:start": "tsx machine.ts"
   },
   "homepage": "https://github.com/inferablehq/inferable#readme",
   "dependencies": {
-    "inferable": "^0.30.94"
+    "inferable": "^0.30.107",
+    "zod": "^3.24.2"
   },
   "devDependencies": {
     "@types/node": "^22.10.1",

--- a/load-tests/run.js
+++ b/load-tests/run.js
@@ -28,12 +28,7 @@ export default function () {
     name: "Load Test",
     initialPrompt: 'Get the special word from the `searchHaystack` function',
     reasoningTraces: false,
-    attachedFunctions: [
-      {
-        function: "searchHaystack",
-        service: "default",
-      },
-    ],
+    tools: ["searchHaystack"],
     resultSchema: {
       type: 'object',
       properties: {

--- a/load-tests/workflow.js
+++ b/load-tests/workflow.js
@@ -1,0 +1,102 @@
+import http from 'k6/http';
+import { sleep, check } from 'k6';
+import { Trend } from 'k6/metrics';
+
+const runTime = new Trend('run_time', true);
+
+export const options = {
+  // K6 defaults
+  // vus: 1,
+  // iterations: 1,
+  // expect all checks to pass
+  thresholds: {
+    checks: ['rate==1.0'],
+  },
+};
+
+const API_SECRET = __ENV.INFERABLE_TEST_API_SECRET
+const CLUSTER_ID = __ENV.INFERABLE_TEST_CLUSTER_ID
+const WORKFLOW_NAME = "searchHaystack"
+const BASE_URL = 'https://api.inferable.ai';
+
+function generateULID() {
+  const random = () => Math.floor(Math.random() * 0x10000).toString(16).padStart(4, "0");
+  const timestamp = Date.now().toString(16).padStart(12, "0");
+  const randomPart = Array.from({ length: 8 }, random).join("");
+  return timestamp + randomPart;
+}
+export default function () {
+  if (!API_SECRET || !CLUSTER_ID) {
+    throw new Error('Missing required environment variables');
+  }
+
+  const executionId = generateULID();
+
+  // Create a new run
+  const postWorkflowResponse = http.post(`${BASE_URL}/clusters/${CLUSTER_ID}/workflows/${WORKFLOW_NAME}/executions`, JSON.stringify({
+    executionId,
+  }), {
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${API_SECRET}`
+    }
+  });
+
+  check(postWorkflowResponse, {
+    'workflow created': (r) => r.status === 201
+  })
+
+  const start = new Date().getTime();
+
+  // Poll the workflow until complete or timeout
+  let attempts = 0;
+  const maxAttempts = 300;
+
+  while (attempts < maxAttempts) {
+    const getWorkflowTimelineResponse = http.get(`${BASE_URL}/clusters/${CLUSTER_ID}/workflows/${WORKFLOW_NAME}/executions/${executionId}/timeline`, {
+      headers: {
+        'Authorization': `Bearer ${API_SECRET}`
+      }
+    });
+
+    const workflow = getWorkflowTimelineResponse.json();
+
+    check(getWorkflowTimelineResponse, {
+      'workflow request succeeded': (r) => r.status === 200
+    });
+
+    if (!workflow) {
+      throw new Error("Workflow request failed");
+    }
+
+    if (workflow.execution.job.status === "success") {
+
+      check(workflow.execution.job, {
+        'workflow completed': (r) => r.status === 'success'
+      });
+
+      // parse JSON
+      const result = JSON.parse(workflow.execution.job.result);
+
+      check(result, {
+        'found needle word': (r) => r.value.word === 'needle'
+      });
+
+      if (! "word" in result) {
+        throw new Error('Missing required result field');
+      }
+
+
+      runTime.add(new Date().getTime() - start);
+
+      break;
+    }
+
+    attempts++;
+    sleep(1);
+  }
+
+  check(attempts, {
+    'attempts < maxAttempts': (a) => a < maxAttempts
+  });
+}


### PR DESCRIPTION
Updates the E2E / Load test to include scripts for testing both a [Workflow](https://docs.inferable.ai/pages/workflows) and individual [Run](https://docs.inferable.ai/pages/runs).

The workflow test it self uses an [Agent step](https://docs.inferable.ai/pages/agents) and [Tool usage](https://docs.inferable.ai/pages/agent-tools) so it pretty much passes through the entire stack.