### PR TITLE
fix: Do not return workflow tools without exact name match

### DIFF
--- a/control-plane/src/modules/tools/index.test.ts
+++ b/control-plane/src/modules/tools/index.test.ts
@@ -1,0 +1,60 @@
+import { createCluster } from "../management";
+import { upsertToolDefinition, getWorkflowTools } from "./";
+
+const schema = "{\"type\":\"object\",\"properties\":{\"foo\":{\"type\":\"string\"}},\"required\":[\"foo\"]}";
+
+describe("getWorkflowTools", () => {
+  let clusterId: string;
+  beforeAll(async () => {
+    const cluster = await createCluster({
+      organizationId: Math.random().toString(),
+      description: "description",
+    });
+    clusterId = cluster.id;
+
+    await upsertToolDefinition({
+      name: "workflows_mySearchWorkflow_1",
+      description: "description",
+      schema,
+      clusterId,
+    });
+
+    await upsertToolDefinition({
+      name: "workflows_mySearchWorkflow_2",
+      description: "description",
+      schema,
+      clusterId,
+    });
+
+  })
+
+  it("should fetch a workflow's tool with multiple versions", async () => {
+    const tools = await getWorkflowTools({
+      clusterId,
+      workflowName: "mySearchWorkflow"
+    });
+
+    expect(tools.length).toBe(2);
+    expect(tools).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        name: "mySearchWorkflow",
+        toolName: "workflows_mySearchWorkflow_1",
+        version: 1,
+      }),
+      expect.objectContaining({
+        name: "mySearchWorkflow",
+        toolName: "workflows_mySearchWorkflow_2",
+        version: 2,
+      }),
+    ]))
+  });
+
+  it("should not return a non-matching workflow", async () => {
+    const tools = await getWorkflowTools({
+      clusterId,
+      workflowName: "mySearch"
+    });
+
+    expect(tools.length).toBe(0);
+  })
+});

--- a/control-plane/src/modules/tools/index.ts
+++ b/control-plane/src/modules/tools/index.ts
@@ -100,6 +100,7 @@ export const getWorkflowTools = async ({
           schema: r.schema
         };
       })
+      .filter(t => t.name == workflowName)
     );
 };
 


### PR DESCRIPTION
It is currently possible to trigger a Workflow with a non-exact match for the name, i.e by providing a subset of the name `search` vs `searchWorkflow`.