### PR TITLE
chore: Better invalid resultSchema errors

### DIFF
--- a/control-plane/src/modules/router.ts
+++ b/control-plane/src/modules/router.ts
@@ -202,11 +202,24 @@ export const router = initServer().router(contract, {
     }
 
     if (body.resultSchema) {
+      if ('type' in body.resultSchema && body.resultSchema.type !== 'object') {
+        return {
+          status: 400,
+          body: {
+            message: "resultSchema must be an object",
+          },
+        };
+      }
+
       const validationError = validateSchema({
         schema: body.resultSchema,
         name: "resultSchema",
       });
       if (validationError) {
+        logger.info("Invalid resultSchema", {
+          resultSchema: body.resultSchema,
+          validationError,
+        })
         return validationError;
       }
     }


### PR DESCRIPTION
The resultSchema should describe an object.
This PR improves the error message when the resultSchema is, for example an array.

This is likely as the FE SDK makes it seem appropriate:
```
  const agent = ctx.agent({
    name: "test",
    systemPrompt: "Return the words 'hello' and 'goodbye'",
    resultSchema: z.array(z.string()),
  })
```