### PR TITLE
chore: Disable hyperDX log collection

### DIFF
--- a/app/instrumentation.ts
+++ b/app/instrumentation.ts
@@ -2,6 +2,8 @@ export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs' && !!process.env.HYPERDX_API_KEY) {
     const { init } = await import('@hyperdx/node-opentelemetry');
     init({
+      disableLogs: true,
+      disableStartupLogs: true,
       apiKey: process.env.HYPERDX_API_KEY,
       service: 'app',
       additionalInstrumentations: [],

--- a/control-plane/src/modules/observability/hyperdx.ts
+++ b/control-plane/src/modules/observability/hyperdx.ts
@@ -43,6 +43,7 @@ hdx?.init({
     },
   },
   advancedNetworkCapture: false,
+  disableLogs: true,
   disableStartupLogs: true,
   stopOnTerminationSignals: false,
 });

--- a/control-plane/src/modules/observability/logger.ts
+++ b/control-plane/src/modules/observability/logger.ts
@@ -1,7 +1,6 @@
 import { createLogger, format, transports } from "winston";
 import { AsyncLocalStorage } from "async_hooks";
 import { env } from "../../utilities/env";
-import { hdx } from "./hyperdx";
 import { rollbar, RollbarTransport } from "./rollbar";
 
 export const logContext = new AsyncLocalStorage();
@@ -24,9 +23,6 @@ const winston = createLogger({
         format.colorize({ all: process.env.NODE_ENV === "development" }),
         format.errors({ stack: true }),
       ),
-    }),
-    hdx?.getWinstonTransport("info", {
-      detectResources: true,
     }),
     env.NODE_ENV === "production"
       ? new RollbarTransport({ level: "warn" }, rollbar)


### PR DESCRIPTION
Disable hyperDX log collection within the application. 

Internally (Inferable cloud) now ships these logs from ECS directly.