### PR TITLE
fix: Instrument more API calls and Redis

### DIFF
--- a/control-plane/package-lock.json
+++ b/control-plane/package-lock.json
@@ -19,6 +19,7 @@
         "@langchain/cohere": "^0.3.1",
         "@langchain/langgraph": "^0.1.9",
         "@nangohq/node": "^0.48.1",
+        "@opentelemetry/instrumentation-redis": "^0.46.1",
         "@slack/bolt": "^4.1.1",
         "@toolhouseai/sdk": "^1.0.4",
         "@ts-rest/core": "^3.27.0",
@@ -8007,6 +8008,23 @@
         "@opentelemetry/api": "^1.4.1"
       }
     },
+    "node_modules/@opentelemetry/auto-instrumentations-node/node_modules/@opentelemetry/instrumentation-redis": {
+      "version": "0.39.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.39.1.tgz",
+      "integrity": "sha512-HUjTerD84jRJnSyDrRPqn6xQ7K91o9qLflRPZqzRvq0GRj5PMfc6TJ/z3q/ayWy/2Kzffhrp7HCIVp0u0TkgUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.51.0",
+        "@opentelemetry/redis-common": "^0.36.2",
+        "@opentelemetry/semantic-conventions": "^1.22.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
     "node_modules/@opentelemetry/context-async-hooks": {
       "version": "1.24.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.24.1.tgz",
@@ -9192,14 +9210,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-redis": {
-      "version": "0.39.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.39.1.tgz",
-      "integrity": "sha512-HUjTerD84jRJnSyDrRPqn6xQ7K91o9qLflRPZqzRvq0GRj5PMfc6TJ/z3q/ayWy/2Kzffhrp7HCIVp0u0TkgUg==",
+      "version": "0.46.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.46.1.tgz",
+      "integrity": "sha512-AN7OvlGlXmlvsgbLHs6dS1bggp6Fcki+GxgYZdSrb/DB692TyfjR7sVILaCe0crnP66aJuXsg9cge3hptHs9UA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.51.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
         "@opentelemetry/redis-common": "^0.36.2",
-        "@opentelemetry/semantic-conventions": "^1.22.0"
+        "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "engines": {
         "node": ">=14"
@@ -9223,6 +9241,62 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-redis/node_modules/@opentelemetry/api-logs": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+      "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-redis/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+      "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.57.2",
+        "@types/shimmer": "^1.2.0",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.2",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-redis/node_modules/import-in-the-middle": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.13.1.tgz",
+      "integrity": "sha512-k2V9wNm9B+ysuelDTHjI9d5KPc4l8zAZTGqj+pcynvWkypZd857ryzN8jNC7Pg2YZXNMJcHRPpaDyCBbNyVRpA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^1.2.2",
+        "module-details-from-path": "^1.0.3"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-redis/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@opentelemetry/instrumentation-restify": {

--- a/control-plane/package.json
+++ b/control-plane/package.json
@@ -30,6 +30,7 @@
     "@langchain/cohere": "^0.3.1",
     "@langchain/langgraph": "^0.1.9",
     "@nangohq/node": "^0.48.1",
+    "@opentelemetry/instrumentation-redis": "^0.46.1",
     "@slack/bolt": "^4.1.1",
     "@toolhouseai/sdk": "^1.0.4",
     "@ts-rest/core": "^3.27.0",

--- a/control-plane/src/modules/observability/hyperdx.ts
+++ b/control-plane/src/modules/observability/hyperdx.ts
@@ -18,28 +18,14 @@ hdx?.init({
   instrumentations: {
     "@opentelemetry/instrumentation-http": {
       enabled: true,
-      ignoreIncomingRequestHook: (req) => {
-        if (req.method === "GET" && req.headers["x-machine-id"]) {
-          // Trace 1% of machine poll `/calls` requests
-          return Math.random() > 0.01;
-        }
-
-        if (req.method === "GET" && req.url?.includes("/timeline")) {
-          // Trace 1% of `/timeline` polls
-          return Math.random() > 0.01;
-        }
-
-        if (req.url?.endsWith("/live")) {
-          return true;
-        }
-
-        return false;
-      },
     },
     "@opentelemetry/instrumentation-pg": {
       enabled: true,
       // This is to prevent tracking new spans for every `/calls` request
       requireParentSpan: true,
+    },
+    "@opentelemetry/instrumentation-redis": {
+      enabled: true,
     },
   },
   advancedNetworkCapture: false,


### PR DESCRIPTION
This will increase our bills, however, we're missing some vital usage/error data that materialise at the request level currently.

This commit adds OpenTelemetry instrumentation for Redis. This allows for tracing and monitoring Redis operations, providing valuable insights into application performance and debugging.
