### PR TITLE
feat(workflow): Remove `effect` function from WorkflowContext

### DIFF
--- a/sdk-node/src/workflows/demo.ts
+++ b/sdk-node/src/workflows/demo.ts
@@ -145,12 +145,6 @@ import { helpers } from "./workflow";
           }),
         });
 
-        ctx.effect(`logFirstAnalyzeLoan`, async () => {
-          console.log(
-            `This side effect will only be run once. It's running for ${record.id}`,
-          );
-        });
-
         const result = await agent2.trigger({
           data: {
             assetClassDetails,

--- a/sdk-node/src/workflows/workflow.ts
+++ b/sdk-node/src/workflows/workflow.ts
@@ -42,7 +42,6 @@ type AgentConfig<TResult> = {
 };
 
 type WorkflowContext<TInput> = {
-  effect: (name: string, fn: () => Promise<void>) => Promise<void>;
   result: <TResult>(
     name: string,
     fn: () => Promise<TResult>,
@@ -149,64 +148,6 @@ export class Workflow<TInput extends WorkflowInput, name extends string> {
 
     return {
       ...jobCtx,
-      effect: async (
-        name: string,
-        fn: (ctx: WorkflowContext<TInput>) => Promise<void>,
-      ) => {
-        const ctx = this.createWorkflowContext(
-          version,
-          executionId,
-          input,
-          jobCtx,
-        );
-
-        const rand = crypto.randomUUID();
-
-        // TODO: async/retry
-        const result = await this.client.setClusterKV({
-          params: {
-            clusterId: await this.getClusterId(),
-            key: `${executionId}_effect_${name}`,
-          },
-          body: {
-            value: rand,
-            onConflict: "doNothing",
-          },
-        });
-
-        if (result.status !== 200) {
-          this.logger?.error("Failed to set effect", {
-            name,
-            executionId,
-            status: result.status,
-          });
-          throw new Error("Failed to set effect");
-        }
-
-        const canRun = result.body.value === rand;
-
-        if (canRun) {
-          this.logger?.info(`Effect ${name} starting execution`, {
-            executionId,
-          });
-          try {
-            await fn(ctx);
-            this.logger?.info(`Effect ${name} completed successfully`, {
-              executionId,
-            });
-          } catch (e) {
-            this.logger?.error(`Effect ${name} failed`, {
-              executionId,
-              error: e,
-            });
-            throw e;
-          }
-        } else {
-          this.logger?.info(`Effect ${name} has already been run`, {
-            executionId,
-          });
-        }
-      },
       result: async <TResult>(
         name: string,
         fn: (ctx: WorkflowContext<TInput>) => Promise<TResult>,


### PR DESCRIPTION
Removes the `ctx.effect` function with at-most-once guarantees due to practical uselessness. We can now use `ctx.result` instead to model side-effect exclusively.