### PR TITLE
feat: Move l1m endpoints under /clusters

### DIFF
--- a/control-plane/src/modules/contract.ts
+++ b/control-plane/src/modules/contract.ts
@@ -1464,6 +1464,33 @@ export const definition = {
     },
   },
 
+  // https://github.com/inferablehq/l1m
+  l1mStructuredV2: {
+    method: "POST",
+    path: "/clusters/:clusterId/l1m/structured",
+    pathParams: z.object({
+      clusterId: z.string(),
+    }),
+    body: z.object({
+      input: z.string(),
+      instruction: z.string().optional(),
+      schema: z.record(z.any()),
+    }),
+    headers: z.object({
+      authorization: z.string(),
+      "x-provider-model": z.string(),
+      "x-provider-url": z.string(),
+      "x-provider-key": z.string(),
+      "x-cache-ttl": z.string().optional(),
+      "x-workflow-execution-id": z.string().optional(),
+    }),
+    responses: {
+      200: z.object({
+        data: z.record(z.any()),
+      }),
+    },
+  },
+
 
 } as const;
 

--- a/sdk-node/src/workflows/workflow.ts
+++ b/sdk-node/src/workflows/workflow.ts
@@ -141,6 +141,7 @@ export class Workflow<TInput extends WorkflowInput, name extends string> {
     executionId: string,
     input: TInput,
     jobCtx: JobContext,
+    clusterId: string,
   ): WorkflowContext<TInput> {
     this.logger?.info("Creating workflow context", {
       version,
@@ -149,7 +150,7 @@ export class Workflow<TInput extends WorkflowInput, name extends string> {
     });
 
     const l1m = new L1M({
-      baseUrl: `${this.endpoint}/l1m`,
+      baseUrl: `${this.endpoint}/clusters/${clusterId}/l1m`,
       provider: {
         model: "claude-3-5-sonnet",
         key: this.apiSecret,
@@ -169,6 +170,7 @@ export class Workflow<TInput extends WorkflowInput, name extends string> {
           executionId,
           input,
           jobCtx,
+          clusterId,
         );
 
         const serialize = (value: unknown) => JSON.stringify({ value });
@@ -351,6 +353,7 @@ export class Workflow<TInput extends WorkflowInput, name extends string> {
             input.executionId,
             input,
             jobCtx,
+            await this.getClusterId(),
           );
           try {
             return await handler(ctx, input);


### PR DESCRIPTION
Moves the `/l1m` endpoints introduced in #844 under the `/clusters/` route and use regular authentication strategies.