### PR TITLE
feat: Render workflow deleted view

### DIFF
--- a/app/app/clusters/[clusterId]/workflows/[workflowName]/executions/[executionId]/page.tsx
+++ b/app/app/clusters/[clusterId]/workflows/[workflowName]/executions/[executionId]/page.tsx
@@ -667,8 +667,9 @@ export default function WorkflowExecutionDetailsPage({
           <AlertCircle className="h-4 w-4" />
           <AlertTitle>Workflow Deleted</AlertTitle>
           <AlertDescription>
-            This workflow execution's data has been deleted according to your
-            cluster's expiry settings. You can adjust these settings in the{" "}
+            This workflow execution&apos;s data has been deleted according to
+            your cluster&apos;s expiry settings. You can adjust these settings
+            in the{" "}
             <Link
               href={`/clusters/${params.clusterId}/settings/details`}
               className="underline"

--- a/app/app/clusters/[clusterId]/workflows/[workflowName]/executions/[executionId]/page.tsx
+++ b/app/app/clusters/[clusterId]/workflows/[workflowName]/executions/[executionId]/page.tsx
@@ -43,6 +43,8 @@ import {
 import React, { useCallback, useEffect, useState } from "react";
 import toast from "react-hot-toast";
 import { EventDetails } from "@/components/event-details";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import Link from "next/link";
 
 type Node = {
   id: string;
@@ -655,6 +657,29 @@ export default function WorkflowExecutionDetailsPage({
 
   if (isLoading || !timeline) {
     return <div className="p-6">Loading...</div>;
+  }
+
+  // Check if the workflow execution has been deleted
+  if (timeline.execution.deletedAt) {
+    return (
+      <div className="p-6">
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>Workflow Deleted</AlertTitle>
+          <AlertDescription>
+            This workflow execution's data has been deleted according to your
+            cluster's expiry settings. You can adjust these settings in the{" "}
+            <Link
+              href={`/clusters/${params.clusterId}/settings/details`}
+              className="underline"
+            >
+              cluster settings
+            </Link>
+            .
+          </AlertDescription>
+        </Alert>
+      </div>
+    );
   }
 
   return (

--- a/app/client/contract.ts
+++ b/app/client/contract.ts
@@ -1,5 +1,6 @@
 import { initContract } from "@ts-rest/core";
 import { z } from "zod";
+import { workflowExecutions } from "./data";
 
 const c = initContract();
 
@@ -1351,6 +1352,7 @@ export const definition = {
             jobId: z.string(),
             createdAt: z.date(),
             updatedAt: z.date(),
+            deletedAt: z.date().nullable().optional(), // Add deletedAt here
           }),
           job: z.object({
             id: z.string().nullable(),
@@ -1435,6 +1437,7 @@ export const definition = {
           workflowName: z.string(),
           workflowVersion: z.number(),
           createdAt: z.date(),
+          deletedAt: z.date().nullable().optional(), // Add deletedAt here
           job: z.object({
             id: z.string(),
             status: z.string(),

--- a/app/client/contract.ts
+++ b/app/client/contract.ts
@@ -1,6 +1,5 @@
 import { initContract } from "@ts-rest/core";
 import { z } from "zod";
-import { workflowExecutions } from "./data";
 
 const c = initContract();
 

--- a/control-plane/src/modules/contract.ts
+++ b/control-plane/src/modules/contract.ts
@@ -1,6 +1,5 @@
 import { initContract } from "@ts-rest/core";
 import { z } from "zod";
-import { workflowExecutions } from "./data";
 
 const c = initContract();
 

--- a/control-plane/src/modules/contract.ts
+++ b/control-plane/src/modules/contract.ts
@@ -1352,6 +1352,7 @@ export const definition = {
             jobId: z.string(),
             createdAt: z.date(),
             updatedAt: z.date(),
+            deletedAt: z.date().nullable().optional(), // Add deletedAt here
           }),
           job: z.object({
             id: z.string().nullable(),
@@ -1436,6 +1437,7 @@ export const definition = {
           workflowName: z.string(),
           workflowVersion: z.number(),
           createdAt: z.date(),
+          deletedAt: z.date().nullable().optional(), // Add deletedAt here
           job: z.object({
             id: z.string(),
             status: z.string(),

--- a/control-plane/src/modules/workflows/executions.ts
+++ b/control-plane/src/modules/workflows/executions.ts
@@ -68,6 +68,7 @@ export const getWorkflowExecutionTimeline = async ({
         workflowVersion: data.workflowExecutions.workflow_version,
         createdAt: data.workflowExecutions.created_at,
         updatedAt: data.workflowExecutions.updated_at,
+        deletedAt: data.workflowExecutions.deleted_at,
         job: {
           id: data.jobs.id,
           clusterId: data.jobs.cluster_id,
@@ -143,6 +144,7 @@ export const listWorkflowExecutions = async ({
       jobId: data.workflowExecutions.job_id,
       createdAt: data.workflowExecutions.created_at,
       updatedAt: data.workflowExecutions.updated_at,
+      deletedAt: data.workflowExecutions.deleted_at,
       jobsId: data.jobs.id,
       jobsStatus: data.jobs.status,
       jobsTargetFn: data.jobs.target_fn,


### PR DESCRIPTION
Deleted workflows will remain within the DB to ensure idempotency, if the UI views one render an explanation.

<img width="1908" alt="image" src="https://github.com/user-attachments/assets/559787cb-a99a-4eec-974e-90ed03178895" />
